### PR TITLE
Add option to manage YUM repository

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,9 @@ The password for the given truststore.
 #####`service_name`
 The name of the rundeck service.
 
+#####`manage_yum_repo`
+Whether to manage the YUM repository containing the Rundeck rpm. Defaults to true.
+
 ####Define: `rundeck::plugin`
 A definition for installing rundeck plugins
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -117,7 +117,8 @@ class rundeck (
   $truststore            = $rundeck::params::truststore,
   $truststore_password   = $rundeck::params::truststore_password,
   $service_name          = $rundeck::params::service_name,
-  $mail_config           = $rundeck::params::mail_config
+  $mail_config           = $rundeck::params::mail_config,
+  $manage_yum_repo       = $rundeck::params::manage_yum_repo,
 
 ) inherits rundeck::params {
 

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -12,6 +12,7 @@ class rundeck::install(
   $package_version    = $rundeck::package_version,
   $package_source     = $rundeck::package_source,
   $package_ensure     = $rundeck::package_ensure,
+  $manage_yum_repo    = $rundeck::manage_yum_repo,
 ) {
 
   if $caller_module_name != $module_name {
@@ -24,13 +25,15 @@ class rundeck::install(
 
   case $::osfamily {
     'RedHat': {
-      yumrepo { 'bintray-rundeck':
-        baseurl  => 'http://dl.bintray.com/rundeck/rundeck-rpm/',
-        descr    => 'bintray rundeck repo',
-        enabled  => '1',
-        gpgcheck => '0',
-        priority => '1',
-        before   => [ Package["rundeck-config-${package_version}"],Package["rundeck-${package_version}"] ],
+      if $manage_yum_repo == true {
+        yumrepo { 'bintray-rundeck':
+          baseurl  => 'http://dl.bintray.com/rundeck/rundeck-rpm/',
+          descr    => 'bintray rundeck repo',
+          enabled  => '1',
+          gpgcheck => '0',
+          priority => '1',
+          before   => [ Package["rundeck-config-${package_version}"],Package["rundeck-${package_version}"] ],
+        }
       }
 
       ensure_resource('package', "rundeck-config-${package_version}", {'ensure' => $package_ensure} )

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -25,6 +25,7 @@ class rundeck::params {
       $service_name = 'rundeckd'
       $jre_name = 'java-1.6.0-openjdk'
       $jre_version = '1.6.0.0-1.66.1.13.0.el6'
+      $manage_yum_repo = true
     }
     default: {
       fail("${::operatingsystem} not supported")


### PR DESCRIPTION
If certain sites use a wrapper for the Puppet yumrepo type, they cannot
disable conflicting yumrepo defined within the module.
