### PR TITLE
Redhat support

### DIFF
--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -19,7 +19,7 @@ class rundeck::service(
         ensure  => present,
         mode    => '0755',
         content => template('rundeck/init.erb'),
-        before  => Service["${service_name}"],
+        before  => Service[$service_name],
       }
   }
 


### PR DESCRIPTION
added logic to only create the init script resource for Debian systems as it doesn't support chkconfig for Red Hat based systems.  This defaults to use of the packaged version on Red Hat.
