### PR TITLE
Plugin refactor

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -2,5 +2,6 @@ fixtures:
   repositories:
     stdlib: "https://github.com/puppetlabs/puppetlabs-stdlib.git"
     inifile: "https://github.com/puppetlabs/puppetlabs-inifile.git"
+    wget: "https://github.com/maestrodev/puppet-wget.git"
   symlinks:
     rundeck: "#{source_dir}"

--- a/README.md
+++ b/README.md
@@ -117,14 +117,8 @@ A definition for installing rundeck plugins
 #####`source`
 The http source or local path from which to get the jar plugin.
 
-#####`plugin_dir`
-The rundeck directory where the plugins are installed to.
-
-#####`user`
-The user that rundeck is installed as.
-
-#####`group`
-The group permission that rundeck is installed as.
+#####`ensure`
+Default set to 'present' and can be set to 'absent' to remove the plugin for the system
 
 ####Define: `rundeck::project`
 A definition for managing rundeck projects

--- a/README.md
+++ b/README.md
@@ -120,6 +120,9 @@ The http source or local path from which to get the jar plugin.
 #####`ensure`
 Default set to 'present' and can be set to 'absent' to remove the plugin for the system
 
+#####`timeout`
+Timeout in seconds.  Default is set to 300 seconds which is the default for the Exec type.
+
 ####Define: `rundeck::project`
 A definition for managing rundeck projects
 

--- a/manifests/config/plugin.pp
+++ b/manifests/config/plugin.pp
@@ -24,7 +24,8 @@
 #
 define rundeck::config::plugin(
   $source,
-  $ensure = 'present',
+  $ensure   = 'present',
+  $timeout  = '300',
 ) {
 
   include '::rundeck'
@@ -47,7 +48,7 @@ define rundeck::config::plugin(
     wget::fetch { "download plugin ${name}":
       source      => $source,
       destination => "${plugin_dir}/${name}",
-      timeout     => 20,
+      timeout     => $timeout,
       verbose     => false,
       require     => File[$plugin_dir],
       before      => File["${plugin_dir}/${name}"]

--- a/manifests/config/plugin.pp
+++ b/manifests/config/plugin.pp
@@ -42,19 +42,30 @@ define rundeck::config::plugin(
   validate_re($group, '[a-zA-Z0-9]{3,}')
   validate_re($ensure, ['^present$', '^absent$'])
 
-  wget::fetch { "download plugin ${name}":
-    source      => $source,
-    destination => "${plugin_dir}/${name}",
-    timeout     => 20,
-    verbose     => false,
-  }
+  if $ensure == 'present' {
 
-  file { "${plugin_dir}/${name}":
-    mode    => '0644',
-    owner   => $user,
-    group   => $group,
-    notify  => Wget::Fetch["download plugin ${name}"],
-    require => File[$plugin_dir],
+    wget::fetch { "download plugin ${name}":
+      source      => $source,
+      destination => "${plugin_dir}/${name}",
+      timeout     => 20,
+      verbose     => false,
+      require     => File[$plugin_dir],
+      before      => File["${plugin_dir}/${name}"]
+    }
+
+    file { "${plugin_dir}/${name}":
+      mode  => '0644',
+      owner => $user,
+      group => $group,
+    }
+
+  }
+  elsif $ensure == 'absent' {
+
+    file { "${plugin_dir}/${name}":
+      ensure => 'absent',
+    }
+
   }
 
 }

--- a/manifests/config/plugin.pp
+++ b/manifests/config/plugin.pp
@@ -28,7 +28,7 @@ define rundeck::config::plugin(
 ) {
 
   include '::rundeck'
-  include wget
+  contain wget
 
   $framework_config = deep_merge($::rundeck::params::framework_config, $::rundeck::framework_config)
 

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -21,6 +21,7 @@ class rundeck::install(
 
   $framework_config = deep_merge($rundeck::params::framework_config, $rundeck::framework_config)
   $projects_dir = $framework_config['framework.projects.dir']
+  $plugin_dir = $framework_config['framework.libext.dir']
 
   ensure_resource('package', $jre_name, {'ensure' => $jre_ensure} )
 
@@ -77,4 +78,5 @@ class rundeck::install(
   }
 
   ensure_resource(file, $projects_dir, {'ensure' => 'directory', 'owner' => $user, 'group' => $group})
+  ensure_resource(file, $plugin_dir, {'ensure'   => 'directory', 'owner' => $user, 'group' => $group})
 }

--- a/metadata.json
+++ b/metadata.json
@@ -32,5 +32,9 @@
       "name": "puppetlabs/inifile",
       "version_requirement": ">= 1.0.3 <2.0.0"
     }
+    {
+      "name": "maestrodev/wget",
+      "version_requirement": ">= 1.5.6 <2.0.0"
+    }
   ]
 }

--- a/spec/classes/install_spec.rb
+++ b/spec/classes/install_spec.rb
@@ -10,6 +10,7 @@ describe 'rundeck' do
           :serialnumber    => 0,
           :rundeck_version => ''
         }}
+        plugin_dir = '/var/lib/rundeck/libext'
 
         if osfamily.eql?('RedHat')
           it { should contain_yumrepo('bintray-rundeck') }
@@ -22,6 +23,10 @@ describe 'rundeck' do
           it { should contain_file('/var/rundeck').with(
             'ensure' => 'directory'
           ) }
+          
+          it { should contain_file(plugin_dir).with(
+          'ensure' => 'directory'
+          ) } 
 
      end
     end

--- a/spec/defines/config/plugin_spec.rb
+++ b/spec/defines/config/plugin_spec.rb
@@ -29,6 +29,29 @@ describe 'rundeck::config::plugin', :type => :define do
           'group'  => 'rundeck'
         )}
       end
+
+      describe "rundeck::config::plugin definition with ensure set to absent on #{osfamily}" do
+        name = 'rundeck-hipchat-plugin-1.0.0.jar'
+        source = 'http://search.maven.org/remotecontent?filepath=com/hbakkum/rundeck/plugins/rundeck-hipchat-plugin/1.0.0/rundeck-hipchat-plugin-1.0.0.jar'
+        plugin_dir = '/var/lib/rundeck/libext'
+
+        let(:title) { name }
+        let(:params) {{
+          'source' => source,
+          'ensure' => 'absent'
+        }}
+
+        let(:facts) {{
+          :osfamily        => 'Debian',
+          :serialnumber    => 0,
+          :rundeck_version => ''
+        }}
+
+        it { should contain_file("#{plugin_dir}/#{name}").with(
+          'ensure' => 'absent'
+          )
+        }
+      end
     end
   end
 end

--- a/spec/defines/config/plugin_spec.rb
+++ b/spec/defines/config/plugin_spec.rb
@@ -19,16 +19,11 @@ describe 'rundeck::config::plugin', :type => :define do
           :rundeck_version => ''
         }}
 
-        it { should contain_file(plugin_dir).with(
-          'ensure' => 'directory'
-        ) }
-
-        it { should contain_exec("download plugin #{name}").with(
-          'command' => "/usr/bin/wget #{source} -O #{plugin_dir}/#{name}"
+        it { should contain_wget__fetch("download plugin #{name}").with(
+          'source' => 'http://search.maven.org/remotecontent?filepath=com/hbakkum/rundeck/plugins/rundeck-hipchat-plugin/1.0.0/rundeck-hipchat-plugin-1.0.0.jar'
         ) }
 
         it { should contain_file("#{plugin_dir}/#{name}").with(
-          'ensure' => 'present',
           'mode'   => '0644',
           'owner'  => 'rundeck',
           'group'  => 'rundeck'


### PR DESCRIPTION
refactored plugin defined type to remove the if/then logic and set defaults when the parameter is declared.  Added the 'ensure' parameter to the defined type to allow removal of an installed plugin. moved the plugin directory resource to the config class to allow multiple plugin definitions.

changed from an exec to download the plugin to using the maestrodev/wget module.  This does add a dependency on that module.