### PR TITLE
Add a jre_manage parameter

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -22,6 +22,11 @@
 # [*jre_ensure*]
 #   Ensure the version of jre to be installed, either present, absent or a specific version
 #
+# [*jre_manage*]
+#   Boolean value to set whether an installation of a JRE should be attempted.
+#   If you set this to true, you are responsible for ensuring the package defined by
+#   jre_name is available.
+#
 # [*auth_type*]
 #   The method used to authenticate to rundeck. Default is file.
 #
@@ -107,6 +112,7 @@ class rundeck (
   $package_source               = $rundeck::params::package_source,
   $jre_name                     = $rundeck::params::jre_name,
   $jre_ensure                   = $rundeck::params::jre_ensure,
+  $jre_manage                   = $rundeck::params::jre_manage,
   $auth_types                   = $rundeck::params::auth_types,
   $auth_template                = $rundeck::params::auth_template,
   $auth_config                  = $rundeck::params::auth_config,

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -9,6 +9,7 @@
 class rundeck::install(
   $jre_name           = $rundeck::jre_name,
   $jre_ensure         = $rundeck::jre_ensure,
+  $jre_manage         = $rundeck::jre_manage,
   $package_source     = $rundeck::package_source,
   $package_ensure     = $rundeck::package_ensure,
   $manage_yum_repo    = $rundeck::manage_yum_repo,
@@ -22,7 +23,9 @@ class rundeck::install(
   $framework_config = deep_merge($rundeck::params::framework_config, $rundeck::framework_config)
   $projects_dir = $framework_config['framework.projects.dir']
 
-  ensure_resource('package', $jre_name, {'ensure' => $jre_ensure} )
+  if $jre_manage {
+    ensure_resource('package', $jre_name, {'ensure' => $jre_ensure} )
+  }
 
   $user = $rundeck::user
   $group = $rundeck::group

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -31,6 +31,8 @@ class rundeck::params {
     }
   }
 
+  $jre_manage = true
+
   $service_manage = false
   $service_config = ''
   $service_script = ''


### PR DESCRIPTION
Allows the user to specify a jre_manage parameter to tell the module not to create a package for the jre. Useful if you already do that elsewhere in your manifest!
