### PR TITLE
Multiple auth users

### DIFF
--- a/spec/classes/config/global/auth_spec.rb
+++ b/spec/classes/config/global/auth_spec.rb
@@ -1,0 +1,104 @@
+require 'spec_helper'
+
+describe 'rundeck' do
+  let(:facts) {{
+    :osfamily        => 'Debian',
+    :fqdn            => 'test.domain.com',
+    :serialnumber    => 0,
+    :rundeck_version => ''
+  }}
+
+  describe 'with empty params' do
+    let(:params) {{
+    }}
+
+    it 'should generate valid content for realm.properties' do
+      content = catalogue.resource('file', '/etc/rundeck/realm.properties')[:content]
+      content.should include('admin:admin,user,admin,architect,deploy,build')
+    end
+  end
+
+  describe 'with empty auth users array' do
+    let(:params) {{
+      :auth_config => {
+        'file' => {
+          'auth_users' => []
+        }
+      }
+    }}
+
+    it 'should generate valid content for realm.properties' do
+      content = catalogue.resource('file', '/etc/rundeck/realm.properties')[:content]
+      content.should include('admin:admin,user,admin,architect,deploy,build')
+    end
+  end
+
+  describe 'with auth users array' do
+    let(:params) {{
+      :auth_config => {
+        'file' => {
+          'auth_users' => [
+            {
+              'username' => 'testuser',
+              'password' => 'password',
+              'roles'    => ['user', 'deploy']
+            },
+            {
+              'username' => 'anotheruser',
+              'password' => 'anotherpassword',
+              'roles'    => ['user']
+            }
+          ]
+        }
+      }
+    }}
+
+    it 'should generate valid content for realm.properties' do
+      content = catalogue.resource('file', '/etc/rundeck/realm.properties')[:content]
+      content.should include('admin:admin,user,admin,architect,deploy,build')
+      content.should include('testuser:password,user,deploy')
+      content.should include('anotheruser:anotherpassword,user')
+    end
+  end
+
+  describe 'with auth user without roles' do
+    let(:params) {{
+      :auth_config => {
+        'file' => {
+          'auth_users' => [
+            {
+              'username' => 'testuser',
+              'password' => 'password'
+            }
+          ]
+        }
+      }
+    }}
+
+    it 'should generate valid content for realm.properties' do
+      content = catalogue.resource('file', '/etc/rundeck/realm.properties')[:content]
+      content.should include('admin:admin,user,admin,architect,deploy,build')
+      content.should include('testuser:password')
+    end
+  end
+
+  describe 'backward compatibility (no array of users)' do
+    let(:params) {{
+      :auth_config => {
+        'file' => {
+          'auth_users' => {
+              'username' => 'testuser',
+              'password' => 'password',
+              'roles'    => ['user', 'deploy']
+          }
+        }
+      }
+    }}
+
+    it 'should generate valid content for realm.properties' do
+      content = catalogue.resource('file', '/etc/rundeck/realm.properties')[:content]
+      content.should include('admin:admin,user,admin,architect,deploy,build')
+      content.should include('testuser:password,user,deploy')
+    end
+  end
+end

--- a/templates/realm.properties.erb
+++ b/templates/realm.properties.erb
@@ -23,18 +23,9 @@
 # This sets the default user accounts for the Rundeck app
 #
 <%= @auth_config['file']['admin_user'] %>:<%= @auth_config['file']['admin_password'] %>,user,admin,architect,deploy,build
-<%- if @auth_config['file']['auth_users']
-      @auth_config['file']['auth_users'].each do |key,value|
-        if key.eql?('username')    -%>
-<%=       value                     %>:
-<%-     elsif key.eql?('password') -%>
-<%=       value                    -%>,
-<%      elsif key.eql?('roles')
-          value.each do |v|        -%>
-<%=         v                      -%>,
-<%-       end
-        else
-        end
-      end
-    end
--%>
+<%- if @auth_config['file']['auth_users'] -%>
+  <%- @auth_config['file']['auth_users'].each do |x| -%>
+<%= x['username'] -%>:<%= x['password'] -%>
+    <%- x['roles'].each do |v| -%>,<%= v -%><%- end %>
+  <%- end -%>
+<%- end %>

--- a/templates/realm.properties.erb
+++ b/templates/realm.properties.erb
@@ -24,10 +24,17 @@
 #
 <%= @auth_config['file']['admin_user'] %>:<%= @auth_config['file']['admin_password'] %>,user,admin,architect,deploy,build
 <%- if @auth_config['file']['auth_users'] -%>
-  <%- @auth_config['file']['auth_users'].each do |x| -%>
+  <%- if @auth_config['file']['auth_users'].kind_of?(Array) -%>
+    <%- @auth_config['file']['auth_users'].each do |x| -%>
 <%= x['username'] -%>:<%= x['password'] -%>
-    <%- if x['roles'] -%>
-      <%- x['roles'].each do |v| -%>,<%= v -%><%- end %>
+      <%- if x['roles'] -%>
+        <%- x['roles'].each do |v| -%>,<%= v -%><%- end %>
+      <%- end -%>
+    <%- end -%>
+  <%- else -%>
+<%= @auth_config['file']['auth_users']['username'] -%>:<%= @auth_config['file']['auth_users']['password'] -%>
+    <%- if @auth_config['file']['auth_users']['roles'] -%>
+      <%- @auth_config['file']['auth_users']['roles'].each do |v| -%>,<%= v -%><%- end %>
     <%- end -%>
   <%- end -%>
 <%- end %>

--- a/templates/realm.properties.erb
+++ b/templates/realm.properties.erb
@@ -26,6 +26,8 @@
 <%- if @auth_config['file']['auth_users'] -%>
   <%- @auth_config['file']['auth_users'].each do |x| -%>
 <%= x['username'] -%>:<%= x['password'] -%>
-    <%- x['roles'].each do |v| -%>,<%= v -%><%- end %>
+    <%- if x['roles'] -%>
+      <%- x['roles'].each do |v| -%>,<%= v -%><%- end %>
+    <%- end -%>
   <%- end -%>
 <%- end %>


### PR DESCRIPTION
Previously it was not possible to create a realm.properties with more than the admin user. Only the admin user would be created with a valid syntax. 
This pull request adds support for an array of users. Roles don't have to be provided as they're optional. Furthermore, the order of a user's properties is not relevant anymore. A line breaking issue and a comma issue have also been fixed. 
Everything comes with tests :)