### PR TITLE
Add option to configure API acls

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -28,7 +28,8 @@ class rundeck::config(
   $service_name          = $rundeck::service_name,
   $mail_config           = $rundeck::mail_config,
   $security_config       = $rundeck::security_config,
-  $acl_policies          = $rundeck::acl_policies
+  $acl_policies          = $rundeck::acl_policies,
+  $api_policies          = $rundeck::api_policies
 ) inherits rundeck::params {
 
   $framework_config = deep_merge($rundeck::params::framework_config, $rundeck::framework_config)

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -118,6 +118,8 @@ class rundeck (
   $auth_config                  = $rundeck::params::auth_config,
   $acl_policies                 = $rundeck::params::acl_policies,
   $acl_template                 = $rundeck::params::acl_template,
+  $api_policies                 = $rundeck::params::api_policies,
+  $api_template                 = $rundeck::params::api_template,
   $service_logs_dir             = $rundeck::params::service_logs_dir,
   $ssl_enabled                  = $rundeck::params::ssl_enabled,
   $framework_config             = $rundeck::params::framework_config,

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -66,6 +66,7 @@ class rundeck::params {
   $auth_template = 'rundeck/jaas-auth.conf.erb'
 
   $acl_template = 'rundeck/admin.aclpolicy.erb'
+  $api_template = 'rundeck/apitoken.aclpolicy.erb'
 
   $acl_policies = [
     {
@@ -100,6 +101,64 @@ class rundeck::params {
         'usernames' => undef
       }
     }
+  ]
+
+  $api_policies = [
+  {
+    'description' => 'API project level access control',
+    'context' => {
+      'type' => 'project',
+      'rule' => '.*'
+    },
+    'resource_types' => [
+      { 'type'  => 'resource', 'rules' => [
+        { 'filter' => { 'filter_type' => 'equals', 'filter_property' => 'kind', 'filter_value' => 'job' },
+         'name' => 'allow',
+         'rule' => ['create','delete'] },
+        { 'filter' => { 'filter_type' => 'equals', 'filter_property' => 'kind', 'filter_value' => 'node' },
+          'name' => 'allow',
+          'rule' => ['read','create','update','refresh'] },
+        { 'filter' => { 'filter_type' => 'equals', 'filter_property' => 'kind', 'filter_value' => 'event' },
+          'name' => 'allow',
+          'rule' => ['read','create'] }]
+      },
+      { 'type'  => 'adhoc', 'rules' => [{'name' => 'allow','rule' => ['read','run','kill']}] },
+      { 'type'  => 'job', 'rules' => [{'name' => 'allow','rule' => ['create','read','update','delete','run','kill']}] },
+      { 'type'  => 'node', 'rules' => [{'name' => 'allow','rule' => ['read','run']}] }
+    ],
+    'by' => {
+      'groups'    => ['api_token_group'],
+      'usernames' => undef
+    }
+  },
+  {
+    'description' => 'API Application level access control',
+    'context' => {
+      'type' => 'application',
+      'rule' => 'rundeck'
+    },
+    'resource_types' => [
+      { 'type'  => 'resource', 'rules' => [
+        { 'filter' => { 'filter_type' => 'equals', 'filter_property' => 'kind', 'filter_value' => 'system' },
+         'name' => 'allow',
+         'rule' => ['read'] }]
+      },
+      { 'type'  => 'project', 'rules' => [
+        { 'filter' => { 'filter_type' => 'match', 'filter_property' => 'name', 'filter_value' => '.*' },
+         'name' => 'allow',
+         'rule' => ['read']}]
+      },
+      { 'type'  => 'storage', 'rules' => [
+        { 'filter' => { 'filter_type' => 'match', 'filter_property' => 'path', 'filter_value' => '(keys|keys/.*)' },
+         'name' => 'allow',
+         'rule' => '*'}]
+      }
+    ],
+    'by' => {
+      'groups'    => ['api_token_group'],
+      'usernames' => undef
+    }
+  }
   ]
 
   $auth_config = {

--- a/templates/apitoken.aclpolicy.erb
+++ b/templates/apitoken.aclpolicy.erb
@@ -1,43 +1,35 @@
-description: API project level access control
+<%- @api_policies.each_with_index do |policy, index| -%>
+description: <%= policy['description'] %>
 context:
-  project: '.*' # all projects
+  <%= policy['context']['type'] %>: '<%= policy['context']['rule'] %>'
 for:
-  resource:
-    - equals:
-        kind: job
-      allow: [create,delete] # allow create and delete jobs
-    - equals:
-        kind: node
-      allow: [read,create,update,refresh] # allow refresh node sources
-    - equals:
-        kind: event
-      allow: [read,create] # allow read/create events
-  adhoc:
-    - allow: [read,run,kill] # allow running/killing adhoc jobs and read output
-  job: 
-    - allow: [create,read,update,delete,run,kill] # allow create/read/write/delete/run/kill of all jobs
-  node:
-    - allow: [read,run] # allow read/run for all nodes
+<%- policy['resource_types'].each do |resource| -%>
+  <%= resource['type'] %>:
+  <%- resource['rules'].each do |rule| -%>
+    - <%- if rule.has_key? 'filter' -%><%= rule['filter']['filter_type'] -%>:
+        <%= rule['filter']['filter_property'] %>: '<%= rule['filter']['filter_value'] -%>'
+      <% end -%><%= rule['name'] %>:
+        <%- rule['rule'].each do |action| -%>
+        - '<%= action %>'
+        <%- end -%>
+  <%- end -%>
+<%- end -%>
 by:
-  group: api_token_group
+<%- if !policy['by']['groups'].nil? && policy['by']['groups'] != :undef -%>
+  group:
+  <%- policy['by']['groups'].each do |group| -%>
+   - '<%= group %>'
+  <%- end -%>
+<%- end -%>
+<%- if !policy['by']['usernames'].nil? && policy['by']['usernames'] != :undef -%>
+  username:
+  <%- policy['by']['usernames'].each do |username| -%>
+   - '<%= username %>'
+  <%- end -%>
+<%- end -%>
+<%- if index != (@api_policies.length-1) -%>
 
 ---
 
-description: API Application level access control
-context:
-  application: 'rundeck'
-for:
-  resource:
-    - equals:
-        kind: system
-      allow: [read] # allow read of system info
-  project:
-    - match:
-        name: '.*'
-      allow: [read] # allow view of all projects
-  storage:
-    - match:
-        path: '(keys|keys/.*)'
-      allow: '*' # allow all access to manage stored keys
-by:
-  group: api_token_group
+<%- end -%>
+<%- end -%>


### PR DESCRIPTION
Hello,

I needed to fiddle with the API acl settings and noticed that the module uses a hardwired template. I changed the template, so it's similar to the existing regular acl template. I made some modifications to enable 'filter' clauses (`match`, `equals`) in the rules. With these changes a semantically equivalent file is generated as before. 

My use case was to allow a specific user **runAs** privileges on certain jobs.