### PR TITLE
This should work on any OS.

### DIFF
--- a/files/rundeck_version
+++ b/files/rundeck_version
@@ -1,5 +1,3 @@
-
-if [ -x /usr/bin/dpkg ]; then
-  VERSION=`dpkg -l | grep rundeck | awk '{ print $3}'`
-  echo "rundeck_version=$VERSION"
-fi
+# Ask puppet what version of rundeck is installed.
+# Will return the version or if not available: "absent".
+puppet resource package rundeck | grep ensure | awk '{print $NF}' | sed "s/'//g;s/,//g"


### PR DESCRIPTION
The previously used code only worked on platforms that have dpkg. Because this uses puppet's RAL, it should run on any platform.

Be aware; either the version is returned, or when not installed, the string "absent" is returned.