### PR TITLE
Fix minor README formatting issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@
 
 The rundeck puppet module for installing and managing rundeck (http://rundeck.org/)
 
-[![Build Status](https://secure.travis-ci.org/opentable/puppet-rundeck.png)](https://secure.travis-ci.org/opentable/puppet-rundeck.png)
+[![Build Status](https://travis-ci.org/puppet-community/puppet-rundeck.svg?branch=master)](https://travis-ci.org/puppet-community/puppet-rundeck)
 
 ##Module Description
 

--- a/README.md
+++ b/README.md
@@ -214,6 +214,7 @@ The group permission that rundeck is installed as.
 ###Classes
 ####Public Classes
 * [`rundeck`](#class-rundeck): Guides the basic installation of rundeck
+
 ####Private Classes
 * [`rundeck::install`](#class-install): Manages the installation of the rundeck packages
 * [`rundeck::service`](#class-service): Manages the rundeck service

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ The rundeck puppet module for installing and managing rundeck (http://rundeck.or
 
 This module provides a way to manage the installation and configuration of rundeck, it's projects, jobs and plugins.
 
-##Setup`
+##Setup
 
 ###Classes and Defined Types
 


### PR DESCRIPTION
There are a few mistakes I noticed while reading this doc; these commits correct them:
* Travis build status image linked to former opentable repo.
* "Setup" had an odd trailing backtick
* "Private Classes" didn't render as a heading