### PR TITLE
Require Java 1.7 for RHEL, per Rundeck reqs (#48)

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -22,7 +22,7 @@ class rundeck::params {
       $package_name = 'rundeck'
       $package_ensure = 'installed'
       $service_name = 'rundeckd'
-      $jre_name = 'java-1.6.0-openjdk'
+      $jre_name = 'java-1.7.0-openjdk'
       $jre_ensure = 'installed'
       $manage_yum_repo = true
     }

--- a/spec/acceptance/rundeck_spec.rb
+++ b/spec/acceptance/rundeck_spec.rb
@@ -37,7 +37,7 @@ describe 'rundeck class' do
       expect(apply_manifest(pp).exit_code).to eq(0)
     end
 
-    describe package('java-1.6.0-openjdk') do
+    describe package('java-1.7.0-openjdk') do
       it { should be_installed }
     end
 

--- a/spec/classes/rundeck_spec.rb
+++ b/spec/classes/rundeck_spec.rb
@@ -18,7 +18,7 @@ describe 'rundeck' do
         it { should contain_class('rundeck').that_requires('rundeck::service') }
 
         if osfamily.eql?('RedHat')
-          it { should contain_package('java-1.6.0-openjdk') }
+          it { should contain_package('java-1.7.0-openjdk') }
         else
           it { should contain_package('openjdk-6-jre') }
         end


### PR DESCRIPTION
As I documented in issue #48, recent versions of Rundeck require Java 1.7 or they crash on startup:

```
Exception in thread "main" java.lang.UnsupportedClassVersionError: com/dtolabs/rundeck/RunServer : Unsupported major.minor version 51.0
...
```

I have only updated the RHEL section; I don't have a Debian host handy to find the OpenJDK versions available and anyway Rundeck itself is locked at an older version for Debian (possibly for this very reason). OpenJDK 1.7.0 is available at least as far back as RHEL/CentOS 5.

(This is a re-creation of PR #49, rebased to the current upstream master and based on a topic branch, instead of my master.)