### PR TITLE
Fix clipped log format without newline (issue #57)

### DIFF
--- a/templates/log4j.properties.erb
+++ b/templates/log4j.properties.erb
@@ -152,4 +152,4 @@ log4j.appender.access=org.apache.log4j.DailyRollingFileAppender
 log4j.appender.access.file=<%= @service_logs_dir %>/rundeck.access.log
 log4j.appender.access.append=true
 log4j.appender.access.layout=org.apache.log4j.PatternLayout
-log4j.appender.access.layout.ConversionPattern=[%d{ISO8601}] "%X{method} %X{uri}" %X{remoteHost} %X{secure} %X{remoteUser} %X{authToken} %X{duration} %X{project} [%X{contentType
+log4j.appender.access.layout.ConversionPattern=[%d{ISO8601}] "%X{method} %X{uri}" %X{remoteHost} %X{secure} %X{remoteUser} %X{authToken} %X{duration} %X{project} [%X{contentType}] (%X{userAgent})%n


### PR DESCRIPTION
Without this patch, the access log file has no newline, so the log is one
very long line. (And the contentType and userAgent are missing.)

(I'm unclear about whether this originated with the template or if it
was from the file distributed with rundeck itself; at any rate, it seems
to be correct upstream).