### PR TITLE
Add support for setting jvm_args (issue #59)

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -11,6 +11,7 @@ class rundeck::config(
   $auth_template         = $rundeck::auth_template,
   $user                  = $rundeck::user,
   $group                 = $rundeck::group,
+  $jvm_args              = $rundeck::jvm_args,
   $ssl_enabled           = $rundeck::ssl_enabled,
   $projects_organization = $rundeck::projects_default_org,
   $projects_description  = $rundeck::projects_default_desc,

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -42,6 +42,9 @@
 # [*group*]
 #   The group that the rundeck user is a member of.
 #
+# [*jvm_args*]
+#   Extra arguments for the JVM.
+#
 # [*rdeck_base*]
 #   The installation directory for rundeck.
 #
@@ -144,6 +147,7 @@ class rundeck (
   $manage_yum_repo              = $rundeck::params::manage_yum_repo,
   $user                         = $rundeck::params::user,
   $group                        = $rundeck::params::group,
+  $jvm_args                     = $rundeck::params::jvm_args,
   $rdeck_home                   = $rundeck::params::rdeck_home,
 ) inherits rundeck::params {
 

--- a/spec/classes/config_spec.rb
+++ b/spec/classes/config_spec.rb
@@ -57,5 +57,20 @@ describe 'rundeck' do
 
       end
     end
+
+    describe 'rundeck::config with jvm_args set' do
+      jvm_args = '-Dserver.http.port=8008 -Xms2048m -Xmx2048m -server'
+      let(:facts) {{
+        :osfamily        => 'RedHat',
+        :serialnumber    => 0,
+        :rundeck_version => ''
+      }}
+      let(:params) {{ :jvm_args => jvm_args }}
+      it { should contain_file('/etc/rundeck/profile') }
+      it 'should generate valid content for profile' do
+        content = catalogue.resource('file', '/etc/rundeck/profile')[:content]
+        content.should include("RDECK_JVM=\"$RDECK_JVM #{jvm_args}\"")
+      end
+    end
   end
 end


### PR DESCRIPTION
With $jvm_args only accessible in rundeck::params, it is not possible
override the values there. It is necessary add to the JVM parameters to
configure rundeckd to listen on a different port than the default and
bind to a specific IP address, both of which are preferred when setting
up Apache httpd to proxy (I want to change the port to one that SELinux
allows httpd to connect to by default, such as 8008); it is also
necessary to add "-Drundeck.jetty.connector.forwarded=true" to enable it
to use the X-Forwarded-* HTTP headers.

I am also just replacing the default from rundeck::params, rather than
merging or concatenating, as I can easily imagine wanting to use
different memory parameters than the ones hard-coded there.