### PR TITLE
Add context for merging potentially conflicting LDAP tests (issues #61 & #62)

### DIFF
--- a/spec/classes/rundeck_spec.rb
+++ b/spec/classes/rundeck_spec.rb
@@ -39,4 +39,14 @@ describe 'rundeck' do
       it { expect { should contain_package('rundeck') }.to raise_error(Puppet::Error, /Nexenta not supported/) }
     end
   end
+
+  context 'non-platform-specific config parameters' do
+    let(:facts) {{
+      :osfamily        => 'RedHat',
+      :serialnumber    => 0,
+      :rundeck_version => ''
+    }}
+
+
+  end
 end


### PR DESCRIPTION
This commit creates an rspec context into which the spec tests for my fixes for issues #61 and #62 will go. I was attempting to make it possible to merge for fixes without conflicts, but I was not wholly successful. At any rate, this is a pre-requisite for the LDAP pull requests #64 and #65.

Note that even with this, #64 and #65 will have conflicts that will have to be managed manually. If you'd like, I can submit another PR that merges both, although it should be fairly obvious how to resolve the conflict.