### PR TITLE
Allow an "url" parameter for LDAP connection (issue #61)

### DIFF
--- a/spec/classes/rundeck_spec.rb
+++ b/spec/classes/rundeck_spec.rb
@@ -39,4 +39,14 @@ describe 'rundeck' do
       it { expect { should contain_package('rundeck') }.to raise_error(Puppet::Error, /Nexenta not supported/) }
     end
   end
+
+  context 'non-platform-specific config parameters' do
+    let(:facts) {{
+      :osfamily        => 'RedHat',
+      :serialnumber    => 0,
+      :rundeck_version => ''
+    }}
+
+
+  end
 end

--- a/spec/classes/rundeck_spec.rb
+++ b/spec/classes/rundeck_spec.rb
@@ -47,6 +47,23 @@ describe 'rundeck' do
       :rundeck_version => ''
     }}
 
-
+    describe 'setting auth_config ldap url' do
+      let(:params) {{
+        :auth_types  => ['ldap'],
+        :auth_config => {
+          'ldap'     => {
+            'url'    => 'ldaps://myrealldap.example.com',
+            'server' => 'fakeldap',
+            'port'   => '983',
+          }
+        }
+      }}
+      it { should contain_file('/etc/rundeck/jaas-auth.conf') }
+      it 'should generate valid content for jaas-auth.conf' do
+        content = catalogue.resource('file', '/etc/rundeck/jaas-auth.conf')[:content]
+        content.should include('providerUrl="ldaps://myrealldap.example.com"')
+        content.should_not include('providerUrl="ldap://fakeldap:983"')
+      end
+    end
   end
 end

--- a/templates/_auth_ldap.erb
+++ b/templates/_auth_ldap.erb
@@ -1,7 +1,16 @@
 com.dtolabs.rundeck.jetty.jaas.JettyCachingLdapLoginModule <%= @ldap_auth_flag %>
   debug="true"
   contextFactory="com.sun.jndi.ldap.LdapCtxFactory"
-  providerUrl="ldap://<%= @auth_config['ldap']['server'] %>:<%= @auth_config['ldap']['port'] %>"
+<%-
+provider_url =  if @auth_config['ldap']['url']
+                    @auth_config['ldap']['url']
+                else
+                    server = @auth_config['ldap']['server']
+                    port = @auth_config['ldap']['port']
+                    "ldap://#{server}:#{port}"
+                end
+-%>
+  providerUrl="<%= provider_url %>"
   authenticationMethod="simple"
   forceBindingLogin="<%= @auth_config['ldap']['force_binding'] %>"
 <%- if @auth_config['ldap']['bind_dn'] != :undef -%>


### PR DESCRIPTION
This commit allows an "url" parameter to be used for `providerURL` instead of building the URL with "server" and "port"; this allows specifying "ldaps" for protocol (issue #61) and makes it more reusable with my existing hiera data.