### PR TITLE
Enable "roleUsernameMemberAttribute" for LDAP auth (issue #62)

### DIFF
--- a/spec/classes/rundeck_spec.rb
+++ b/spec/classes/rundeck_spec.rb
@@ -39,4 +39,14 @@ describe 'rundeck' do
       it { expect { should contain_package('rundeck') }.to raise_error(Puppet::Error, /Nexenta not supported/) }
     end
   end
+
+  context 'non-platform-specific config parameters' do
+    let(:facts) {{
+      :osfamily        => 'RedHat',
+      :serialnumber    => 0,
+      :rundeck_version => ''
+    }}
+
+
+  end
 end

--- a/spec/classes/rundeck_spec.rb
+++ b/spec/classes/rundeck_spec.rb
@@ -47,6 +47,25 @@ describe 'rundeck' do
       :rundeck_version => ''
     }}
 
+    # auth_config cannot be passed as a parameter to rundeck::config :-(
+    # so we have to test it here
+    describe 'setting auth_config ldap roleUsernameMemberAttribute' do
+      let(:params) {{
+        :auth_types => [ 'ldap' ],
+        :auth_config => {
+          'ldap' => {
+            'role_username_member_attribute' => 'memberUid'
+          }
+        }
+      }}
+      it { should contain_file('/etc/rundeck/jaas-auth.conf') }
+      it 'should generate valid content for jaas-auth.conf' do
+        content = catalogue.resource('file', '/etc/rundeck/jaas-auth.conf')[:content]
+        content.should include('roleUsernameMemberAttribute="memberUid"')
+        content.should_not include('roleMemberAttribute')
+      end
+    end
+
 
   end
 end

--- a/templates/_auth_ldap.erb
+++ b/templates/_auth_ldap.erb
@@ -16,7 +16,11 @@ com.dtolabs.rundeck.jetty.jaas.JettyCachingLdapLoginModule <%= @ldap_auth_flag %
   userObjectClass="<%= @auth_config['ldap']['user_object_class'] %>"
   roleBaseDn="<%= @auth_config['ldap']['role_base_dn'] %>"
   roleNameAttribute="<%= @auth_config['ldap']['role_name_attribute'] %>"
+<%- if @auth_config['ldap']['role_username_member_attribute'] -%>
+  roleUsernameMemberAttribute="<%= @auth_config['ldap']['role_username_member_attribute'] %>"
+<%- elsif @auth_config['ldap']['role_member_attribute'] -%>
   roleMemberAttribute="<%= @auth_config['ldap']['role_member_attribute'] %>"
+<%- end -%>
   roleObjectClass="<%= @auth_config['ldap']['role_object_class'] %>"
 <%- if @auth_config['ldap']['supplemental_roles'] != :undef -%>
   supplementalRoles="<%= @auth_config['ldap']['supplemental_roles'] %>"


### PR DESCRIPTION
 For sites using RFC 2307 posixGroup for roles, the *roleMemberAttribute* does not work, because the posixGroup *memberUid* attributes are usernames and not DNs; the *roleUsernameMemberAttribute* is for this.
