### PR TITLE
bugfix/#43 - rundeck service is not restarted after upgraded in CentOS

### DIFF
--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -44,6 +44,7 @@ class rundeck::install(
       }
 
       ensure_resource('package', 'rundeck', {'ensure' => $package_ensure, notify => Class['rundeck::service'] } )
+      ensure_resource('package', 'rundeck-config', {'ensure' => $package_ensure, notify => Class['rundeck::service'] } )
     }
     'Debian': {
 

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -43,7 +43,7 @@ class rundeck::install(
         }
       }
 
-      ensure_resource('package', 'rundeck', {'ensure' => $package_ensure} )
+      ensure_resource('package', 'rundeck', {'ensure' => $package_ensure, notify => Class['rundeck::service'] } )
     }
     'Debian': {
 


### PR DESCRIPTION
- rundeck service is not restarted after upgraded in CentOS