### PR TITLE
Fixed admin.aclpolicy params

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -95,6 +95,7 @@ class rundeck::params {
       'resource_types' => [
         { 'type'  => 'resource', 'rules' => [{'name' => 'allow','rule' => '*'}] },
         { 'type'  => 'project', 'rules' => [{'name' => 'allow','rule' => '*'}] },
+        { 'type'  => 'storage', 'rules' => [{'name' => 'allow','rule' => '*'}] },
       ],
       'by' => {
         'groups'    => ['admin'],


### PR DESCRIPTION
The storage rule was missing, so the admin user was not able to create a storage record