### PR TITLE
bugfix/#79 -use ${pd} variable to replace /var/lib/rundeck/libext, if not default value

### DIFF
--- a/manifests/config/plugin.pp
+++ b/manifests/config/plugin.pp
@@ -65,7 +65,7 @@ define rundeck::config::plugin(
 
   exec { "download plugin ${name}":
     command => "/usr/bin/wget ${source} -O ${pd}/${name}",
-    unless  => "/bin/ls -l /var/lib/rundeck/libext/ | grep ${name}"
+    unless  => "/bin/ls ${pd}/${name} 2>/dev/null"
   }
 
   file { "${pd}/${name}":


### PR DESCRIPTION
- use ${pd} variable to replace /var/lib/rundeck/libext, if not default value
- mute the output
- merge ls + grep within one ls command