### PR TITLE
Add class to manage security-role in web.xml

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,9 @@ A hash of the notification email configuraton.
 #####`security_config`
 A hash of the rundeck security configuration.
 
+#####`security_role`
+The name of the role that is required for all users to be allowed access.
+
 #####`manage_yum_repo`
 Whether to manage the YUM repository containing the Rundeck rpm. Defaults to true.
 

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -32,6 +32,7 @@ class rundeck::config(
   $service_name          = $rundeck::service_name,
   $mail_config           = $rundeck::mail_config,
   $security_config       = $rundeck::security_config,
+  $security_role         = $rundeck::security_role,
   $acl_policies          = $rundeck::acl_policies,
   $api_policies          = $rundeck::api_policies
 ) inherits rundeck::params {
@@ -148,4 +149,9 @@ class rundeck::config(
   }
 
   create_resources(rundeck::config::project, $projects)
+
+  class { 'rundeck::config::global::web':
+    security_role => $security_role,
+    notify        => Service[$service_name],
+  }
 }

--- a/manifests/config/global/web.pp
+++ b/manifests/config/global/web.pp
@@ -1,0 +1,25 @@
+# Author::    Wil Cooley <wcooley(at)nakedape.cc>
+# License::   MIT
+#
+# == Class: rundeck::config::global::web
+#
+# Manage the application's +web.xml+.
+#
+# Currently only manages the +<security-role>+ required for any user to login:
+# http://rundeck.org/docs/administration/authenticating-users.html#security-role
+#
+# === Parameters
+#
+# [*security_role*]
+#   Name of role that is required for all users to be allowed access.
+#
+class rundeck::config::global::web (
+  $security_role = $rundeck::params::security_role,
+) inherits rundeck::params {
+
+  augeas { 'rundeck/web.xml/security-role/role-name':
+    lens    => 'Xml.lns',
+    incl    => $rundeck::params::web_xml,
+    changes => [ "set web-app/security-role/role-name/#text '${security_role}'" ],
+  }
+}

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -88,6 +88,9 @@
 # [*security_config*]
 #  A hash of the rundeck security configuration.
 #
+# [*security_role*]
+#  Name of the role that is required for all users to be allowed access.
+#
 # [*user*]
 #   The user that rundeck is installed as.
 #
@@ -140,6 +143,7 @@ class rundeck (
   $service_config               = $rundeck::params::service_config,
   $mail_config                  = $rundeck::params::mail_config,
   $security_config              = $rundeck::params::security_config,
+  $security_role                = $rundeck::params::security_role,
   $manage_yum_repo              = $rundeck::params::manage_yum_repo,
   $user                         = $rundeck::params::user,
   $group                        = $rundeck::params::group,

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -268,4 +268,7 @@ class rundeck::params {
   $ssl_port = '4443'
 
   $package_source = 'https://dl.bintray.com/rundeck/rundeck-deb'
+
+  $web_xml = "${rdeck_base}/exp/webapp/WEB-INF/web.xml"
+  $security_role = 'user'
 }

--- a/spec/classes/config/global/web_spec.rb
+++ b/spec/classes/config/global/web_spec.rb
@@ -1,0 +1,26 @@
+require 'spec_helper'
+
+describe 'rundeck' do
+  let(:facts) {{
+    :osfamily        => 'RedHat',
+    :fqdn            => 'test.example.com',
+    :serialnumber    => 0,
+    :rundeck_version => ''
+  }}
+
+  context 'with empty params' do
+    it 'should generate augeas resource with default security_role' do
+      should contain_augeas('rundeck/web.xml/security-role/role-name') \
+        .with_changes(["set web-app/security-role/role-name/#text 'user'"])
+    end
+  end
+
+  context 'with security_role param' do
+    let(:params) {{ :security_role => 'superduper' }}
+
+    it 'should generate augeas resource with specified security_role' do
+      should contain_augeas('rundeck/web.xml/security-role/role-name') \
+        .with_changes(["set web-app/security-role/role-name/#text 'superduper'"])
+    end
+  end
+end


### PR DESCRIPTION
To change the `security-role` currently one must edit `web.xml` directly, and reapply the change upon upgrade, as that file is version-specific and must be kept in sync with the application. I have opened an issue with rundeck to make that configurable via something in `/etc/rundeck` (rundeck/rundeck#1261), but unless or until that is resolved, I need to be able to manage it.

This creates a `rundeck::config::global::web` class with this as the sole parameter which is also added and passed through `rundeck` and `rundeck::config`. I chose to use an *augeas* resource because the file is XML and needs to be replaced outside of Puppet, so a template would not work. Many people have an aversion to augeas because it can get complicated; I find that for certain classes of problems it can be fairly easy. The only hitch is that testing augeas commands is non-trivial (requires [rspec-puppet-augeas](/domcleal/rspec-puppet-augeas) which was broken for a while due to rspec-puppet).

I would also like to be able to set the `session-timeout` in `web.xml` so if this approach is acceptable I will add that to the `...::web` class.