### PR TITLE
Fix for #72 - bug with non-default user and group

### DIFF
--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -73,6 +73,27 @@ class rundeck::install(
       err("The osfamily: ${::osfamily} is not supported")
     }
   }
+
+  if $group == 'rundeck' {
+    ensure_resource('group', 'rundeck', { 'ensure' => 'present' } )
+  } else {
+    ensure_resource('group', $group, { 'ensure' => 'present' } )
+    
+    group { 'rundeck':
+      ensure => absent,
+    }
+  }
+
+  if $user == 'rundeck' {
+    ensure_resource('user', $user, { 'ensure' => 'present', 'groups' => [$group] } )
+  } else {
+    ensure_resource('user', $user, { 'ensure' => 'present', 'groups' => [$group] } )
+    
+    user { 'rundeck':
+      ensure => absent,
+    }
+  }
+
   file { $rdeck_home:
     ensure => directory,
     owner  => $user,

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -38,7 +38,7 @@ class rundeck::params {
   $service_script = ''
 
   $rdeck_base = '/var/lib/rundeck'
-  $rdeck_home = '/var/rundeck'
+  $rdeck_home = '/var/lib/rundeck'
   $service_logs_dir = '/var/log/rundeck'
 
   $framework_config = {

--- a/spec/classes/install_spec.rb
+++ b/spec/classes/install_spec.rb
@@ -19,11 +19,42 @@ describe 'rundeck' do
           it { should_not contain_yumrepo('bintray-rundeck') }
         end
 
-          it { should contain_file('/var/rundeck').with(
-            'ensure' => 'directory'
-          ) }
+        it { should contain_file('/var/lib/rundeck').with(
+          'ensure' => 'directory'
+        )}
 
+        it { should contain_user('rundeck').with(
+          'ensure' => 'present'
+        )}
      end
     end
+  end
+
+  describe 'different user and group' do 
+    let(:params) {{
+      :user  => 'A1234',
+      :group => 'A1234'
+    }}
+    let(:facts) {{
+      :osfamily        => 'Debian',
+      :serialnumber    => 0,
+      :rundeck_version => ''
+    }}
+
+    it { should contain_group('A1234').with(
+      'ensure' => 'present'
+    )}
+
+    it { should contain_group('rundeck').with(
+      'ensure' => 'absent'
+    )}
+
+    it { should contain_user('A1234').with(
+      'ensure' => 'present'
+    )}
+
+    it { should contain_user('rundeck').with(
+      'ensure' => 'absent'
+    )} 
   end
 end


### PR DESCRIPTION
The rundeck package will create a default user and group of 'rundeck' if
a non-default user and group is specified by this module then we want to
make sure that they are created properly, that the rundeck defaults are
removed and that all directories have the correct permissions.