### PR TITLE
Add server.web.context argument

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,9 @@ The group that the Rundeck user is a member of.
 #####`rdeck_base`
 The installation directory for Rundeck.
 
+#####`server_web_context`
+Web context path to use, such as "/rundeck". http://host.domain:port/server_web_context
+
 #####`ssl_enabled`
 Enable ssl for the Rundeck web application.
 

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -11,6 +11,7 @@ class rundeck::config(
   $auth_template         = $rundeck::auth_template,
   $user                  = $rundeck::user,
   $group                 = $rundeck::group,
+  $server_web_context    = $rundeck::server_web_context,
   $jvm_args              = $rundeck::jvm_args,
   $ssl_enabled           = $rundeck::ssl_enabled,
   $projects_organization = $rundeck::projects_default_org,

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -99,6 +99,9 @@
 # [*group*]
 #   The group permission that rundeck is installed as.
 #
+# [*server_web_context*]
+#   Web context path to use, such as "/rundeck". http://host.domain:port/server_web_context
+#
 # [*rdeck_home*]
 #   directory under which the projects directories live.
 # === Examples
@@ -177,6 +180,7 @@ class rundeck (
   validate_hash($mail_config)
   validate_string($user)
   validate_string($group)
+  validate_string($server_web_context)
   validate_absolute_path($rdeck_home)
 
   class { 'rundeck::facts': } ->

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -147,6 +147,7 @@ class rundeck (
   $manage_yum_repo              = $rundeck::params::manage_yum_repo,
   $user                         = $rundeck::params::user,
   $group                        = $rundeck::params::group,
+  $server_web_context           = $rundeck::params::server_web_context,
   $jvm_args                     = $rundeck::params::jvm_args,
   $rdeck_home                   = $rundeck::params::rdeck_home,
 ) inherits rundeck::params {

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -273,6 +273,7 @@ class rundeck::params {
 
   $resource_sources = {}
 
+  $server_web_context = undef
   $jvm_args = '-Xmx1024m -Xms256m -server'
 
   $ssl_enabled = false

--- a/templates/profile.erb
+++ b/templates/profile.erb
@@ -22,12 +22,15 @@ export RDECK_JVM="-Drdeck.config=<%= @properties_dir %> \
 -Djava.security.auth.login.config=<%= @properties_dir %>/jaas-auth.conf \
 -Dloginmodule.name=authentication"
 
+<%- if @server_web_context -%>
+RDECK_JVM="$RDECK_JVM -Dserver.web.context=<%= @server_web_context %>"
+<%- end -%>
 
 RDECK_JVM="$RDECK_JVM <%= @jvm_args %>"
 
-<% if @ssl_enabled %>
+<%- if @ssl_enabled -%>
 export RDECK_JVM="$RDECK_JVM -Drundeck.ssl.config=<%= @properties_dir %>/ssl/ssl.properties -Dserver.https.port=<%= @ssl_port %>"
-<% end %>
+<%- end -%>
 
 export RDECK_SSL_OPTS="-Djavax.net.ssl.trustStore=$RDECK_BASE/ssl/truststore -Djavax.net.ssl.trustStoreType=jks -Djava.protocol.handler.pkgs=com.sun.net.ssl.internal.www.protocol"
 


### PR DESCRIPTION
The java system properties server.web.context is needed to modify the context path. That's usefull behind a proxy.
So I propose to add this argument

Sources : http://rundeck.org/docs/administration/installation.html#system-properties

Note: I corrected the style in the profile.erb