### PR TITLE
Jetty combined ldap

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -205,6 +205,7 @@ class rundeck::params {
     }
   }
 
+
   $mail_config = {}
 
   $security_config = {

--- a/templates/_auth_ad.erb
+++ b/templates/_auth_ad.erb
@@ -1,4 +1,4 @@
-com.dtolabs.rundeck.jetty.jaas.JettyCachingLdapLoginModule <%= @active_directory_auth_flag %>
+com.dtolabs.rundeck.jetty.jaas.<%= @ldap_login_module %> <%= @active_directory_auth_flag %>
   debug="true"
   contextFactory="com.sun.jndi.ldap.LdapCtxFactory"
   providerUrl="ldap://<%= @auth_config['active_directory']['server'] %>:<%= @auth_config['active_directory']['port'] %>"
@@ -25,4 +25,18 @@ com.dtolabs.rundeck.jetty.jaas.JettyCachingLdapLoginModule <%= @active_directory
   <%- end -%>
   cacheDurationMillis="300000"
   reportStatistics="true"
+<%- if @ldap_login_module == 'JettyCombinedLdapLoginModule' -%>
+  ignoreRoles="true"
+  storePass="true"
+  clearPass="true"
+  useFirstPass="false"
+  tryFirstPass="false"
+<%- end -%>
   nestedGroups="<%= @auth_config['active_directory']['nested_groups'] %>";
+
+<%- if @ldap_login_module == 'JettyCombinedLdapLoginModule' -%>
+org.rundeck.jaas.jetty.JettyRolePropertyFileLoginModule required
+  debug="true"
+  useFirstPass="true"
+  file="<%= @auth_config['file']['file'] %>";
+<%- end -%>

--- a/templates/_auth_ldap.erb
+++ b/templates/_auth_ldap.erb
@@ -1,4 +1,4 @@
-com.dtolabs.rundeck.jetty.jaas.JettyCachingLdapLoginModule <%= @ldap_auth_flag %>
+com.dtolabs.rundeck.jetty.jaas.<%= @ldap_login_module %> <%= @ldap_auth_flag %>
   debug="true"
   contextFactory="com.sun.jndi.ldap.LdapCtxFactory"
 <%-
@@ -36,4 +36,18 @@ provider_url =  if @auth_config['ldap']['url']
 <%- end -%>
   cacheDurationMillis="300000"
   reportStatistics="true"
+<%- if @ldap_login_module == 'JettyCombinedLdapLoginModule' -%>
+  ignoreRoles="true"
+  storePass="true"
+  clearPass="true"
+  useFirstPass="false"
+  tryFirstPass="false"
+<%- end -%>
   nestedGroups="<%= @auth_config['ldap']['nested_groups'] %>";
+
+<%- if @ldap_login_module == 'JettyCombinedLdapLoginModule' -%>
+org.rundeck.jaas.jetty.JettyRolePropertyFileLoginModule required
+  debug="true"
+  useFirstPass="true"
+  file="<%= @auth_config['file']['file'] %>";
+<%- end -%>

--- a/templates/jaas-auth.conf.erb
+++ b/templates/jaas-auth.conf.erb
@@ -2,9 +2,9 @@ authentication {
 
   <%- @auth_types.each do |type|
         case type
-        when 'ldap' -%>
+        when 'ldap', 'ldap_shared' -%>
   <%=     scope.function_template(['rundeck/_auth_ldap.erb']) %>
-  <%-   when 'active_directory' -%>
+  <%-   when 'active_directory', 'active_directory_shared' -%>
   <%=     scope.function_template(['rundeck/_auth_ad.erb']) %>
   <%-   when 'pam' -%>
   <%=     scope.function_template(['rundeck/_auth_pam.erb']) %>

--- a/templates/realm.properties.erb
+++ b/templates/realm.properties.erb
@@ -26,7 +26,7 @@
 <%- if @auth_config['file']['auth_users'] -%>
   <%- if @auth_config['file']['auth_users'].kind_of?(Array) -%>
     <%- @auth_config['file']['auth_users'].each do |x| -%>
-<%= x['username'] -%>:<%= x['password'] -%>
+<%= x['username'] -%>:<%= x.fetch('password', '-') -%>
       <%- if x['roles'] -%>
         <%- x['roles'].each do |v| -%>,<%= v -%><%- end %>
       <%- end -%>


### PR DESCRIPTION
Before applying this, please see https://github.com/puppet-community/puppet-rundeck/issues/94 and https://github.com/puppet-community/puppet-rundeck/issues/96 as these fixes were merged to this feature branch (JettyCombinedLdap). 

-------
Since Rundeck 2.5 there is a new very useful feature:  LDAP "shared authentication credentials". 
see http://rundeck.org/docs/administration/authenticating-users.html#ldap for more details.

This pull request provides puppet's implementation of that feature 

to activate this feature $auth_types should be assigned as 
- ldap_shared

**or**
- active_directory_shared

That means that rundeck will authenticate user with LDAP (or AD) and will perform authorization with FileLoginModule (realm file) to assign provided roles
- http://rundeck.org/docs/administration/authenticating-users.html#jettyrolepropertyfileloginmodule