### PR TITLE
added properties_dir when instantiating aclpolicyfile type

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -83,11 +83,13 @@ class rundeck::config(
   }
 
   rundeck::config::aclpolicyfile { 'admin':
-    acl_policies => $acl_policies,
+    properties_dir => $properties_dir,
+    acl_policies   => $acl_policies,
   }
 
   rundeck::config::aclpolicyfile { 'apitoken':
-    acl_policies => $api_policies,
+    properties_dir => $properties_dir,
+    acl_policies   => $api_policies,
   }
 
   file { "${properties_dir}/profile":


### PR DESCRIPTION
The properties_dir property of aclpolicyfile is defaulted to the value of the properties directory in the framework, but I'm not sure if the framework property is properly scoped in the defined type (ie: when I vagrant up my rundeck box, the value is null).  Regardless, recommend the properties_dir from config is passed into the 'admin' and 'aclpolicyfile' files in this context -- this provides a correct value to the type.