### PR TITLE
Fix the projects directory default in framework.properies.

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -43,7 +43,7 @@ class rundeck::params {
     'framework.server.username' => 'admin',
     'framework.server.password' => 'admin',
     'rdeck.base'                => '/var/lib/rundeck',
-    'framework.projects.dir'    => '/var/rundeck/projects',
+    'framework.projects.dir'    => '/var/lib/rundeck/projects',
     'framework.etc.dir'         => '/etc/rundeck',
     'framework.var.dir'         => '/var/lib/rundeck/var',
     'framework.tmp.dir'         => '/var/lib/rundeck/var/tmp',

--- a/spec/acceptance/rundeck_spec.rb
+++ b/spec/acceptance/rundeck_spec.rb
@@ -14,7 +14,7 @@ describe 'rundeck class' do
       EOS
 
       # Run it twice and test for idempotency
-      expect(apply_manifest(pp).exit_code).to_not eq(1)
+      expect(apply_manifest(pp, :expect_changes => true).exit_code).to eq(2)
       expect(apply_manifest(pp).exit_code).to eq(0)
     end
 

--- a/spec/classes/config/global/framework_spec.rb
+++ b/spec/classes/config/global/framework_spec.rb
@@ -19,7 +19,7 @@ describe 'rundeck' do
           'framework.server.url' => 'http://test.domain.com:4440',
           'framework.server.username' => 'admin',
           'framework.server.password' => 'admin',
-          'framework.projects.dir' => '/var/rundeck/projects',
+          'framework.projects.dir' => '/var/lib/rundeck/projects',
           'framework.etc.dir' => '/etc/rundeck',
           'framework.var.dir' => '/var/lib/rundeck/var',
           'framework.tmp.dir' => '/var/lib/rundeck/var/tmp',

--- a/spec/classes/config/global/project_spec.rb
+++ b/spec/classes/config/global/project_spec.rb
@@ -12,9 +12,9 @@ describe 'rundeck' do
         }}
 
         project_details = {
-          'project.dir' => '/var/rundeck/projects/${project.name}',
-          'project.etc.dir' => '/var/rundeck/projects/${project.name}/etc',
-          'project.resources.file' => '/var/rundeck/projects/${project.name}/etc/resources.xml',
+          'project.dir' => '/var/lib/rundeck/projects/${project.name}',
+          'project.etc.dir' => '/var/lib/rundeck/projects/${project.name}/etc',
+          'project.resources.file' => '/var/lib/rundeck/projects/${project.name}/etc/resources.xml',
           'project.description' => '',
           'project.organization' => ''
         }

--- a/spec/classes/config_spec.rb
+++ b/spec/classes/config_spec.rb
@@ -43,7 +43,7 @@ describe 'rundeck' do
           content.should include('-Drundeck.server.configDir=/etc/rundeck')
           content.should include('-Dserver.datastore.path=/var/lib/rundeck/data')
           content.should include('-Drundeck.server.serverDir=/var/lib/rundeck')
-          content.should include('-Drdeck.projects=/var/rundeck/projects')
+          content.should include('-Drdeck.projects=/var/lib/rundeck/projects')
           content.should include('-Drdeck.runlogs=/var/lib/rundeck/logs')
           content.should include('-Drundeck.config.location=/etc/rundeck/rundeck-config.groovy')
           content.should include('-Djava.security.auth.login.config=/etc/rundeck/jaas-auth.conf')

--- a/spec/defines/config/resource_source_spec.rb
+++ b/spec/defines/config/resource_source_spec.rb
@@ -22,20 +22,20 @@ describe 'rundeck::config::resource_source', :type => :define do
           'resources.source.1.config.includeServerNode' => 'false',
           'resources.source.1.config.generateFileAutomatically' => 'true',
           'resources.source.1.config.format' => 'resourcexml',
-          'resources.source.1.config.file' => '/var/rundeck/projects/test/etc/source one.xml',
+          'resources.source.1.config.file' => '/var/lib/rundeck/projects/test/etc/source one.xml',
           'resources.source.1.type' => 'file'
         }
 
         file_details.each do |key,value|
           it { should contain_ini_setting("source one::#{key}").with(
-            'path'    => '/var/rundeck/projects/test/etc/project.properties',
+            'path'    => '/var/lib/rundeck/projects/test/etc/project.properties',
             'setting' => key,
             'value'   => value
           ) }
         end
 
         it do
-          should contain_file('/var/rundeck/projects/test').with(
+          should contain_file('/var/lib/rundeck/projects/test').with(
             'owner' => 'rundeck',
             'group' => 'rundeck'
             )
@@ -66,7 +66,7 @@ describe 'rundeck::config::resource_source', :type => :define do
 
         url_details.each do |key,value|
           it { should contain_ini_setting("source one::#{key}").with(
-            'path'    => '/var/rundeck/projects/test/etc/project.properties',
+            'path'    => '/var/lib/rundeck/projects/test/etc/project.properties',
             'setting' => key,
             'value'   => value
           ) }
@@ -94,7 +94,7 @@ describe 'rundeck::config::resource_source', :type => :define do
 
         directory_details.each do |key,value|
           it { should contain_ini_setting("source one::#{key}").with(
-            'path'    => '/var/rundeck/projects/test/etc/project.properties',
+            'path'    => '/var/lib/rundeck/projects/test/etc/project.properties',
             'setting' => key,
             'value'   => value
           ) }
@@ -131,7 +131,7 @@ describe 'rundeck::config::resource_source', :type => :define do
 
         script_details.each do |key,value|
           it { should contain_ini_setting("source one::#{key}").with(
-            'path'    => '/var/rundeck/projects/test/etc/project.properties',
+            'path'    => '/var/lib/rundeck/projects/test/etc/project.properties',
             'setting' => key,
             'value'   => value
           ) }


### PR DESCRIPTION
This was not caught by the systems tests either which is what was shown
in issue #91.

This commit fixes the default back to $RDECK_BASE/projects and updates
the tests to catch these in the future.