### PR TITLE
Fix for #100 deep merging issue with aclpolicyfile

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -83,11 +83,17 @@ class rundeck::config(
   }
 
   rundeck::config::aclpolicyfile { 'admin':
-    acl_policies => $acl_policies,
+    acl_policies   => $acl_policies,
+    owner          => $user,
+    group          => $group,
+    properties_dir => $properties_dir,
   }
 
   rundeck::config::aclpolicyfile { 'apitoken':
-    acl_policies => $api_policies,
+    acl_policies   => $api_policies,
+    owner          => $user,
+    group          => $group,
+    properties_dir => $properties_dir,
   }
 
   file { "${properties_dir}/profile":

--- a/manifests/config/aclpolicyfile.pp
+++ b/manifests/config/aclpolicyfile.pp
@@ -64,9 +64,9 @@
 #
 define rundeck::config::aclpolicyfile(
   $acl_policies,
-  $owner          = $rundeck::user,
-  $group          = $rundeck::group,
-  $properties_dir = $rundeck::framework_config['framework.etc.dir'],
+  $owner          = 'rundeck',
+  $group          = 'rundeck',
+  $properties_dir = '/etc/rundeck',
 ) {
 
   validate_array($acl_policies)

--- a/spec/defines/config/aclpolicyfile_spec.rb
+++ b/spec/defines/config/aclpolicyfile_spec.rb
@@ -1,50 +1,63 @@
 require 'spec_helper'
 
 describe 'rundeck::config::aclpolicyfile', :type => :define do
+  
+  test_policies = [
+    {
+      'description' => 'Admin, all access',
+      'context' => {
+        'type' => 'project',
+        'rule' => '.*'
+      },
+      'resource_types' => [
+        { 'type'  => 'resource', 'rules' => [{'name' => 'allow','rule' => '*'}] }
+      ],
+      'by' => {
+        'groups'    => ['admin'],
+      }
+    },
+    {
+      'description' => 'Admin, all access',
+      'context' => {
+        'type' => 'application',
+        'rule' => 'rundeck'
+      },
+      'resource_types' => [
+        { 'type'  => 'resource', 'rules' => [{'name' => 'allow','rule' => '*'}] }
+      ],
+      'by' => {
+        'groups'    => ['admin'],
+      }
+    }
+  ]
 
-    let(:title) {'myPolicy'}
+  context 'default parameters' do
+    let(:title) { 'defaultPolicy' }
     let(:params) {{
-        :acl_policies   =>
-          [
-              {
-                'description' => 'Admin, all access',
-                'context' => {
-                  'type' => 'project',
-                  'rule' => '.*'
-                },
-                'resource_types' => [
-                  { 'type'  => 'resource', 'rules' => [{'name' => 'allow','rule' => '*'}] }
-                ],
-                'by' => {
-                  'groups'    => ['admin'],
-                }
-              },
-              {
-                'description' => 'Admin, all access',
-                'context' => {
-                  'type' => 'application',
-                  'rule' => 'rundeck'
-                },
-                'resource_types' => [
-                  { 'type'  => 'resource', 'rules' => [{'name' => 'allow','rule' => '*'}] }
-                ],
-                'by' => {
-                  'groups'    => ['admin'],
-                }
-              }
-          ],
-        :properties_dir => '/etc/rundeck',
-        :owner => 'myUser',
-        :group => 'myGroup',
+      :acl_policies => test_policies
+    }}
+
+    it { should contain_file('/etc/rundeck/defaultPolicy.aclpolicy').with({
+      'owner' => 'rundeck',
+      'group' => 'rundeck',
+      'mode'  => '0640',
+    })}
+  end
+
+  context 'custom parameters' do
+    let(:title) { 'myPolicy' }
+    let(:params) {{
+      :acl_policies   => test_policies,
+      :properties_dir => '/etc/rundeck-acl',
+      :owner          => 'myUser',
+      :group          => 'myGroup',
 		}}
 
-    it { should contain_file('/etc/rundeck/myPolicy.aclpolicy').with(
-          {
-            'owner' => 'myUser',
-            'group' => 'myGroup',
-            'mode' => '0640',
-          }
-    )}
-
+    it { should contain_file('/etc/rundeck-acl/myPolicy.aclpolicy').with({
+      'owner' => 'myUser',
+      'group' => 'myGroup',
+      'mode'  => '0640',
+    })}
+  end
 end
 


### PR DESCRIPTION
Updated the parameter defaults to fixed values not inherited from the
root rundeck class because it avoids any issues if the define is used on
it's own (not sure why you would do that) and also allows me to write a
test for the default case of the properties.dir setting.

Due to the above change I also update the config.pp file accordingly to
pass-through the remaining parameters.