### PR TITLE
fetching packages over tls instead of clear test

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -272,5 +272,5 @@ class rundeck::params {
   $ssl_enabled = false
   $ssl_port = '4443'
 
-  $package_source = 'http://dl.bintray.com/rundeck/rundeck-deb'
+  $package_source = 'https://dl.bintray.com/rundeck/rundeck-deb'
 }


### PR DESCRIPTION
The package is fetched over simple http for debian based distribution.
As the site `https://dl.bintray.com/rundeck/rundeck-deb` now support tls, I changed the source parameter to use https by default. 