### PR TITLE
(#108) Add support for customizing rundeck-config

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -34,7 +34,8 @@ class rundeck::config(
   $security_config       = $rundeck::security_config,
   $security_role         = $rundeck::security_role,
   $acl_policies          = $rundeck::acl_policies,
-  $api_policies          = $rundeck::api_policies
+  $api_policies          = $rundeck::api_policies,
+  $rdeck_config_template = $rundeck::rdeck_config_template,
 ) inherits rundeck::params {
 
   $framework_config = deep_merge($rundeck::params::framework_config, $rundeck::framework_config)

--- a/manifests/config/global/rundeck_config.pp
+++ b/manifests/config/global/rundeck_config.pp
@@ -7,16 +7,17 @@
 # This private class is called from rundeck::config used to manage the rundeck-config properties
 #
 class rundeck::config::global::rundeck_config(
-  $rd_loglevel         = $rundeck::config::loglevel,
-  $rdeck_base          = $rundeck::config::rdeck_base,
-  $rss_enabled         = $rundeck::config::rss_enabled,
-  $clustermode_enabled = $rundeck::config::clustermode_enabled,
-  $grails_server_url   = $rundeck::config::grails_server_url,
-  $properties_dir      = $rundeck::config::properties_dir,
-  $user                = $rundeck::config::user,
-  $group               = $rundeck::config::group,
-  $mail_config         = $rundeck::config::mail_config,
-  $security_config     = $rundeck::config::security_config
+  $rd_loglevel           = $rundeck::config::loglevel,
+  $rdeck_base            = $rundeck::config::rdeck_base,
+  $rss_enabled           = $rundeck::config::rss_enabled,
+  $clustermode_enabled   = $rundeck::config::clustermode_enabled,
+  $grails_server_url     = $rundeck::config::grails_server_url,
+  $properties_dir        = $rundeck::config::properties_dir,
+  $user                  = $rundeck::config::user,
+  $group                 = $rundeck::config::group,
+  $mail_config           = $rundeck::config::mail_config,
+  $security_config       = $rundeck::config::security_config,
+  $rdeck_config_template = $rundeck::config::rdeck_config_template,
 ) {
 
   $properties_file = "${properties_dir}/rundeck-config.groovy"
@@ -31,7 +32,7 @@ class rundeck::config::global::rundeck_config(
 
   file { $properties_file:
     ensure  => present,
-    content => template('rundeck/rundeck-config.erb'),
+    content => template($rdeck_config_template),
     owner   => $user,
     group   => $group,
     mode    => '0640',

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -151,6 +151,7 @@ class rundeck (
   $jvm_args                     = $rundeck::params::jvm_args,
   $java_home                    = $rundeck::params::java_home,
   $rdeck_home                   = $rundeck::params::rdeck_home,
+  $rdeck_config_template        = $rundeck::params::rdeck_config_template,
 ) inherits rundeck::params {
 
   #validate_re($package_ensure, '\d+\.\d+\.\d+')

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -271,4 +271,6 @@ class rundeck::params {
 
   $web_xml = "${rdeck_base}/exp/webapp/WEB-INF/web.xml"
   $security_role = 'user'
+
+  $rdeck_config_template = 'rundeck/rundeck-config.erb'
 }


### PR DESCRIPTION
There are customizations to `rundeck-config` that I would like to do. Using the `rdeck_config_template`, I could specify a template for it. By default, it would use `rundeck/rundeck-config.erb`.

PS: My first contribution to puppet-rundeck, please comment on my diff.