### PR TITLE
(#110) Add support for customizing realm.properties

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -9,6 +9,7 @@
 class rundeck::config(
   $auth_types            = $rundeck::auth_types,
   $auth_template         = $rundeck::auth_template,
+  $realm_template        = $rundeck::realm_template,
   $user                  = $rundeck::user,
   $group                 = $rundeck::group,
   $server_web_context    = $rundeck::server_web_context,
@@ -65,7 +66,7 @@ class rundeck::config(
       owner   => $user,
       group   => $group,
       mode    => '0640',
-      content => template('rundeck/realm.properties.erb'),
+      content => template($realm_template),
       require => File[$properties_dir],
       notify  => Service[$service_name],
     }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -117,6 +117,7 @@ class rundeck (
   $auth_types                   = $rundeck::params::auth_types,
   $auth_template                = $rundeck::params::auth_template,
   $auth_config                  = $rundeck::params::auth_config,
+  $realm_template               = $rundeck::params::realm_template,
   $acl_policies                 = $rundeck::params::acl_policies,
   $acl_template                 = $rundeck::params::acl_template,
   $api_policies                 = $rundeck::params::api_policies,

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -205,6 +205,7 @@ class rundeck::params {
     },
   }
 
+  $realm_template = 'rundeck/realm.properties.erb'
 
   $mail_config = {}
 


### PR DESCRIPTION
Using `realm_template`, `realm.properties` could be customized. By default, `rundeck/realm.properties.erb` is used.