### PR TITLE
(#112) Add `aws-ec2` as resource_source to support Rundeck EC2 Nodes Plugin

### DIFF
--- a/manifests/config/resource_source.pp
+++ b/manifests/config/resource_source.pp
@@ -81,6 +81,9 @@ define rundeck::config::resource_source(
   $script_args         = '',
   $script_args_quoted  = $rundeck::params::script_args_quoted,
   $script_interpreter  = $rundeck::params::script_interpreter,
+  $mapping_params      = '',
+  $use_default_mapping = true,
+  $running_only        = true,
 ) {
 
   include rundeck
@@ -97,7 +100,7 @@ define rundeck::config::resource_source(
 
   validate_string($project_name)
   validate_re($number, '[1-9]*')
-  validate_re($source_type, ['^file$', '^directory$', '^url$', '^script$'])
+  validate_re($source_type, ['^file$', '^directory$', '^url$', '^script$', '^aws-ec2$'])
   validate_bool($include_server_node)
   validate_absolute_path($projects_dir)
   validate_re($user, '[a-zA-Z0-9]{3,}')
@@ -283,6 +286,32 @@ define rundeck::config::resource_source(
         setting => "resources.source.${number}.config.argsQuoted",
         value   => $script_args_quoted,
         require => File[$properties_file]
+      }
+    }
+    'aws-ec2': {
+      ini_setting { "resources.source.${number}.config.mappingParams":
+        ensure  => present,
+        path    => $properties_file,
+        section => '',
+        setting => "resources.source.${number}.config.mappingParams",
+        value   => $mapping_params,
+        require => File[$properties_file],
+      }
+      ini_setting { "resources.source.${number}.config.useDefaultMapping":
+        ensure  => present,
+        path    => $properties_file,
+        section => '',
+        setting => "resources.source.${number}.config.useDefaultMapping",
+        value   => $use_default_mapping,
+        require => File[$properties_file],
+      }
+      ini_setting { "resources.source.${number}.config.runningOnly":
+        ensure  => present,
+        path    => $properties_file,
+        section => '',
+        setting => "resources.source.${number}.config.runningOnly",
+        value   => $running_only,
+        require => File[$properties_file],
       }
     }
     default: {


### PR DESCRIPTION
Add `aws-ec2` as resource_source to support [Rundeck EC2 Nodes Plugin](https://github.com/rundeck-plugins/rundeck-ec2-nodes-plugin).