### PR TITLE
Set java_home directory

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -12,6 +12,7 @@ class rundeck::config(
   $user                  = $rundeck::user,
   $group                 = $rundeck::group,
   $jvm_args              = $rundeck::jvm_args,
+  $java_home             = $rundeck::java_home,
   $ssl_enabled           = $rundeck::ssl_enabled,
   $projects_organization = $rundeck::projects_default_org,
   $projects_description  = $rundeck::projects_default_desc,

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -34,6 +34,9 @@
 # [*jvm_args*]
 #   Extra arguments for the JVM.
 #
+# [*java_home*]
+#   Set the home directory of java.
+#
 # [*rdeck_base*]
 #   The installation directory for rundeck.
 #
@@ -134,6 +137,7 @@ class rundeck (
   $user                         = $rundeck::params::user,
   $group                        = $rundeck::params::group,
   $jvm_args                     = $rundeck::params::jvm_args,
+  $java_home                    = $rundeck::params::java_home,
   $rdeck_home                   = $rundeck::params::rdeck_home,
 ) inherits rundeck::params {
 

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -269,6 +269,8 @@ class rundeck::params {
 
   $jvm_args = '-Xmx1024m -Xms256m -server'
 
+  $java_home = undef
+
   $ssl_enabled = false
   $ssl_port = '4443'
 

--- a/templates/profile.erb
+++ b/templates/profile.erb
@@ -1,6 +1,10 @@
 RDECK_BASE=<%= @rdeck_base %>
 export RDECK_BASE
 
+<% if @java_home %>
+export JAVA_HOME=<%= @java_home %>
+<% end %>
+
 JAVA_CMD=java
 
 if [ ! -z $JAVA_HOME ]; then


### PR DESCRIPTION
Default it will look to the environment settings JAVA_HOME.
We install java by just unpacking a packages in a directory.

So it would be nice if this can be set optionally.