### PR TITLE
A new function to validate the acl policies

### DIFF
--- a/lib/puppet/parser/functions/validate_rd_policy.rb
+++ b/lib/puppet/parser/functions/validate_rd_policy.rb
@@ -1,0 +1,23 @@
+require 'puppet/util/rundeck_acl'
+
+module Puppet::Parser::Functions
+
+  newfunction(:validate_rd_policy, :doc => <<-'ENDHEREDOC') do |args|
+
+    ENDHEREDOC
+
+    unless args.length == 1 then
+      raise Puppet::ParseError, ("validate_rd_policy(): wrong number of arguments (#{args.length}; must be 1)")
+    end
+
+    args.each do |arg|
+      if arg.is_a?(Array)
+
+      elsif arg.is_a?(Hash)
+        Puppet::Util::RundeckACL.validate_acl(arg)
+      else
+        raise Puppet::ParseError, ("#{arg.inspect} is not a Hash or Array of hashes.  It looks to be a #{arg.class}")
+      end
+    end
+  end
+end

--- a/lib/puppet/util/rundeck_acl.rb
+++ b/lib/puppet/util/rundeck_acl.rb
@@ -1,0 +1,314 @@
+module Puppet::Util::RundeckACL
+  
+  class RundeckValidator
+
+    def raise_err(msg)
+      raise(Puppet::ParseError, "The policy is invalid - #{msg}")
+    end
+
+    def validate_description(description)
+      if !description.is_a? String
+        raise_err('description is not a String')
+      end
+    end
+
+    def validate_context(context)
+      if !context.is_a? Hash
+        raise_err('context is not a Hash')
+      elsif context.empty?
+        raise_err('context is empty')
+      else
+        if context.keys.length != 1
+          raise_err('context can only contain project or application')
+        else
+          type = context.keys[0]
+          
+          case type
+          when 'project', 'application'
+            if !context[type].is_a? String
+              raise_err("context:#{type} is not a String")
+            end
+          else
+            raise_err("context can only be project or application")
+          end
+
+        end
+      end
+    end
+
+    def validate_rule_action(type, type_section, scope)
+      action_found = false
+      actions = []
+      property = ''
+      value = ''
+
+      if type_section.empty?
+        raise_err("for:#{type} is empty")
+      end
+      type_section.each do |e|
+        if !e.is_a? Hash
+          raise_err("for:#{type} entry is not a Hash")
+        end
+      end
+
+      type_section.each do |e|
+        e.each do |k,v|
+          if k.eql?('allow') or k.eql?('deny')
+            action_found = true
+            actions = v
+          elsif ['match','equals','contains'].include?(k)
+            case type
+            when 'resource'
+              property = v['kind']
+            when 'job'
+              if v['name']
+                property = 'name'
+                value = v['name']
+              elsif v['group']
+                property = 'group'
+                value = v['group']
+              else
+                property = v.keys[0]
+              end
+            when 'project'
+              if v['name']
+                property = 'name'
+                value = v['name']
+              else
+                property = v.keys[0]
+              end
+            when 'storage'
+              if v['name']
+                property = 'name'
+                value = v['name']
+              elsif v['path']
+                property = 'path'
+                value = v['path']
+              else
+                property = v.keys[0]
+              end
+            else
+              #
+            end
+          end
+        end
+
+        if !action_found
+          raise_err("for:#{type} does not contain a rule action of [allow,deny]")
+        else
+          if scope.eql?('project')
+            if property.to_s != '' or type.eql?('adhoc') or type.eql?('node')
+              validate_proj_actions(type, actions, property, value)
+            end
+          elsif scope.eql?('application')
+            validate_app_actions(type, actions, property, value) 
+          end
+        end
+      end
+      
+    end
+
+    def validate_proj_actions(type, actions, property, value='')
+      project_actions = {
+        'resource' => {
+          'job'   => ['create','delete'],
+          'node'  => ['read','create','update','refresh'],
+          'event' => ['read','create']
+         },
+        'adhoc' => ['read','run','runAs','kill','killAs'],
+        'job' => {
+          'name' => ['read','update','delete','run','runAs','kill','killAs','create'],
+          'group' => ['read','update','delete','run','runAs','kill','killAs','create']
+        },
+        'node' => ['read','run']
+      }
+
+      case type
+      when 'resource'
+        case property
+        when 'job', 'node', 'event'
+          actions.each do |action|
+            if !project_actions[type][property].include?(action)
+              raise_err("for:resource kind:#{property} can only contain actions #{project_actions[type][property]}")
+            end
+          end
+        else
+          #
+        end
+      when 'adhoc', 'node'
+       actions.each do |action|
+        if !project_actions[type].include?(action)
+          raise_err("for:#{type} can only contain actions #{project_actions[type]}") 
+        end
+       end
+      when 'job'
+        case property
+        when 'name','group'
+          actions.each do |action|
+            if !project_actions[type][property].include?(action)
+              raise_err("for:job #{property}:#{value} can only contain actions #{project_actions[type][property]}")
+            end
+          end
+        else
+          raise_err("#{property} is not a valid property for the job scope")
+        end
+      else
+        #
+      end
+    end
+
+    def validate_app_actions(type, actions, property, value='')
+      app_actions = {
+        'resource' => {
+          'project' => ['create'],
+          'system'  => ['read'],
+          'user'    => ['admin'],
+          'job'     => ['admin']
+        },
+        'project' => {
+          'name' => ['read','configure','delete','import','export','delete_execution','admin']
+        },
+        'storage' => {
+          'name' => ['create','update','read','delete'],
+          'path' => ['create','update','read','delete']
+        }
+      }
+
+      case type
+      when 'resource'
+        case property
+        when 'project', 'system','user','job'
+          actions.each do |action|
+            if !app_actions[type][property].include?(action)
+              raise_err("for:resource kind:#{property} can only contain actions #{app_actions[type][property]}")
+            end
+          end
+        else
+        end
+      when 'project'
+        if property.eql?('name')
+          actions.each do |action|
+            if !app_actions[type][property].include?(action)
+              raise_err("for:project #{property} can only contain actions #{app_actions[type][property]}")
+            end
+          end
+        end
+      when 'storage'
+        p "LB: #{type}"
+        p "LB: #{property}"
+        case property
+        when 'name', 'path'
+          actions.each do |action|
+            if !app_actions[type][property].include?(action)
+              raise_err("for:storage #{property} can only contain actions #{app_actions[type][property]}")
+            end
+          end
+        else
+        end
+      else
+        #
+      end
+    end
+
+    def validate_matching(type, type_section)
+      matching_found = false
+      if type_section.empty?
+        raise_err("for:#{type} is empty")
+      end
+      type_section.each do |e|
+        if e.is_a? Hash
+          e.each do |k,v|
+            if k.eql?('match') or k.eql?('equals') or k.eql?('contains')
+              matching_found = true
+            end
+          end
+        else
+          raise_err("for:#{type} entry is not a Hash")
+        end
+      end
+      if !matching_found
+        raise_err("for:#{type} does not contain a matching statement of [match,equals,contains]")
+      end
+    end
+
+    def validate_for(for_section, context)
+      if !for_section.is_a? Hash
+        raise_err("for is not a Hash")
+      elsif for_section.empty?
+        raise_err("for is empty")          
+      else
+        scope = context.keys[0]
+
+        if scope.eql?('project')
+          resource_types = ['job','node','adhoc','project','resource']
+        elsif scope.eql?('application')
+          resource_types = ['resource','project','storage']
+        else
+          raise_err("unknown scope: #{scope}")
+        end
+
+        for_section.each do |k,v|
+          if !resource_types.include?(k)
+            raise_err("for section must only contain #{resource_types.inspect.gsub!('"',"'")}")
+          end
+        end
+           
+        resource_types.each do |type|
+          if for_section.has_key?(type)
+            if !for_section[type].is_a? Array
+              raise_err("for:#{type} is not an Array")
+            elsif for_section[type].empty?
+              raise_err("for:#{type} is empty")
+            else
+              validate_rule_action(type, for_section[type], scope)
+              validate_matching(type, for_section[type]) unless for_section[type].eql?('adhoc')
+            end
+          end
+        end
+      end
+    end
+
+    def validate_by(by_section)
+      if !by_section.is_a? Array
+       raise_err("by is not an Array")
+      elsif by_section.empty?
+       raise_err("by is empty")
+      else
+
+        by_section.each do |item|
+          if !item.is_a? Hash
+            raise_err("by:#{item} is not a Hash")
+          elsif item.empty?
+            raise_err("by is empty")
+          else
+            
+          item.each do |k,v|
+            if !['username','group'].include?(k)
+              raise_err("by section must only contain [username,group]")
+            end
+          end
+
+            ['username','group'].each do |type|
+              if item.has_key?(type)
+                if !item[type].is_a? String and !item[type].is_a? Array
+                  raise_err("by:#{type} is not a String or an Array")
+                end
+              end
+            end
+          end
+        end 
+      end 
+    end
+
+  end
+
+  def validate_acl(hash)
+    rv = RundeckValidator.new
+    rv.validate_description(hash['description'])
+    rv.validate_context(hash['context'])
+    rv.validate_for(hash['for'], hash['context'])
+    rv.validate_by(hash['by'])
+  end
+
+  module_function :validate_acl
+end

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -161,6 +161,7 @@ class rundeck (
   validate_string($user)
   validate_string($group)
   validate_absolute_path($rdeck_home)
+  validate_rd_policy($acl_policies)
 
   class { 'rundeck::facts': } ->
   class { 'rundeck::install': } ->

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -66,107 +66,88 @@ class rundeck::params {
     {
       'description' => 'Admin, all access',
       'context' => {
-        'type' => 'project',
-        'rule' => '.*'
+        'project' => '.*'
       },
-      'resource_types' => [
-        { 'type'  => 'resource', 'rules' => [{'name' => 'allow','rule' => '*'}] },
-        { 'type'  => 'adhoc', 'rules' => [{'name' => 'allow','rule' => '*'}] },
-        { 'type'  => 'job', 'rules' => [{'name' => 'allow','rule' => '*'}] },
-        { 'type'  => 'node', 'rules' => [{'name' => 'allow','rule' => '*'}] }
-      ],
-      'by' => {
-        'groups'    => ['admin'],
-        'usernames' => undef
-      }
+      'for' => {
+        'resource' => [
+          {'allow' => '*'}
+        ],
+        'adhoc' => [
+          {'allow' => '*'}
+        ],
+        'job' => [
+          {'allow' => '*'}
+        ],
+        'node' => [
+          {'allow' => '*'}
+        ]
+      },
+      'by' => [{
+        'group' => ['admin']
+      }]
     },
     {
       'description' => 'Admin, all access',
       'context' => {
-        'type' => 'application',
-        'rule' => 'rundeck'
+        'application' => 'rundeck'
       },
-      'resource_types' => [
-        { 'type'  => 'resource', 'rules' => [{'name' => 'allow','rule' => '*'}] },
-        { 'type'  => 'project', 'rules' => [{'name' => 'allow','rule' => '*'}] },
-        { 'type'  => 'storage', 'rules' => [{'name' => 'allow','rule' => '*'}] },
-      ],
-      'by' => {
-        'groups'    => ['admin'],
-        'usernames' => undef
-      }
+      'for' => {
+        'resource' => [
+          {'allow' => '*'}
+        ],
+        'project' => [
+          {'allow' => '*'}
+        ]
+      },
+      'by' => [{
+        'group' => ['admin']
+      }]
     }
   ]
 
   $api_policies = [
-  {
-    'description' => 'API project level access control',
-    'context' => {
-      'type' => 'project',
-      'rule' => '.*'
+    {
+      'description' => 'API project level access control',
+      'context' => {
+        'project' => '.*'
+      },
+      'for' => {
+        'resource' => [
+          { 'equals' => {'kind' => 'job'}, 'allow' => ['create','delete'] },
+          { 'equals' => {'kind' => 'node'}, 'allow' => ['read','create','update','refresh'] },
+          { 'equals' => {'kind' => 'event'}, 'allow' => ['read','create'] }
+        ],
+        'adhoc' => [
+          {'allow' => ['read','run','kill']}
+        ],
+        'node' => [
+          {'allow' => ['read','run']}
+        ]
+      },
+      'by' => [{
+        'group' => ['api_token_group']
+      }]
     },
-    'resource_types' => [
-      {
-        'type'  => 'resource', 'rules' => [
-          { 'filter' => { 'filter_type' => 'equals', 'filter_property' => 'kind', 'filter_value' => 'job' },
-            'name' => 'allow',
-            'rule' => ['create','delete']
-          },
-          { 'filter' => { 'filter_type' => 'equals', 'filter_property' => 'kind', 'filter_value' => 'node' },
-            'name' => 'allow',
-            'rule' => ['read','create','update','refresh']
-          },
-          { 'filter' => { 'filter_type' => 'equals', 'filter_property' => 'kind', 'filter_value' => 'event' },
-            'name' => 'allow',
-            'rule' => ['read','create']
-          }
+    {
+      'description' => 'API Application level access control',
+      'context' => {
+        'application' => 'rundeck'
+      },
+      'for' => {
+        'resource' => [
+          { 'equals' => {'kind' => 'system'}, 'allow' => ['read'] }
+        ],
+        'project' => [
+          { 'match' => {'name' => '.*'}, 'allow' => ['read'] }
+        ],
+        'storage' => [
+          { 'match' => {'path' => '(keys|keys/.*)'}, 'allow' => '*' }
         ]
       },
-      { 'type'  => 'adhoc', 'rules' => [{'name' => 'allow','rule' => ['read','run','kill']}] },
-      { 'type'  => 'job', 'rules' => [{'name' => 'allow','rule' => ['create','read','update','delete','run','kill']}] },
-      { 'type'  => 'node', 'rules' => [{'name' => 'allow','rule' => ['read','run']}] }
-    ],
-    'by' => {
-      'groups'    => ['api_token_group'],
-      'usernames' => undef
+      'by' => [{
+        'group' => ['api_token_group']
+      }]
     }
-  },
-  {
-    'description' => 'API Application level access control',
-    'context' => {
-      'type' => 'application',
-      'rule' => 'rundeck'
-    },
-    'resource_types' => [
-      {
-        'type'  => 'resource', 'rules' => [
-          { 'filter' => { 'filter_type' => 'equals', 'filter_property' => 'kind', 'filter_value' => 'system' },
-            'name' => 'allow',
-            'rule' => ['read']
-          }
-        ]
-      },
-      {
-        'type'  => 'project', 'rules' => [
-          { 'filter' => { 'filter_type' => 'match', 'filter_property' => 'name', 'filter_value' => '.*' },
-            'name' => 'allow',
-            'rule' => ['read']
-          }
-        ]
-      },
-      { 'type'  => 'storage', 'rules' => [
-          { 'filter' => { 'filter_type' => 'match', 'filter_property' => 'path', 'filter_value' => '(keys|keys/.*)' },
-            'name' => 'allow',
-            'rule' => '*'
-          }
-        ]
-      }
-    ],
-    'by' => {
-      'groups'    => ['api_token_group'],
-      'usernames' => undef
-    }
-  }
   ]
 
   $auth_config = {

--- a/spec/classes/rundeck_spec.rb
+++ b/spec/classes/rundeck_spec.rb
@@ -11,6 +11,7 @@ describe 'rundeck' do
           :rundeck_version => ''
         }}
 
+        it { should compile }
         it { should contain_class('rundeck::params') }
         it { should contain_class('rundeck::install').that_comes_before('rundeck::config') }
         it { should contain_class('rundeck::config') }

--- a/spec/defines/config/aclpolicyfile_spec.rb
+++ b/spec/defines/config/aclpolicyfile_spec.rb
@@ -6,28 +6,30 @@ describe 'rundeck::config::aclpolicyfile', :type => :define do
     {
       'description' => 'Admin, all access',
       'context' => {
-        'type' => 'project',
-        'rule' => '.*'
+        'project' => '.*',
       },
-      'resource_types' => [
-        { 'type'  => 'resource', 'rules' => [{'name' => 'allow','rule' => '*'}] }
-      ],
-      'by' => {
-        'groups'    => ['admin'],
-      }
+      'for' => {
+        'resource' => [
+          { 'equals' => {'kind' => 'job'}, 'allow' => ['create'] }
+        ]
+      },    
+      'by' => [
+        {'group' => ['admin']},
+      ]
     },
     {
       'description' => 'Admin, all access',
       'context' => {
-        'type' => 'application',
-        'rule' => 'rundeck'
+        'application' => 'rundeck'
       },
-      'resource_types' => [
-        { 'type'  => 'resource', 'rules' => [{'name' => 'allow','rule' => '*'}] }
-      ],
-      'by' => {
-        'groups'    => ['admin'],
-      }
+      'for' => {
+        'resource' => [
+          { 'equals' => {'kind' => 'project'}, 'allow' => ['create'] }
+        ]
+      },
+      'by' => [
+        {'groups' => ['admin']},
+      ]
     }
   ]
 

--- a/spec/functions/validate_rd_policy/application_spec.rb
+++ b/spec/functions/validate_rd_policy/application_spec.rb
@@ -1,0 +1,522 @@
+require 'spec_helper'
+
+describe 'validate_rd_policy' do
+
+  describe 'application policy' do
+    describe 'valid policy' do
+      test_policy = {
+        'description' => 'Admin, all access',
+        'context' => {
+          'application' => 'rundeck'
+        },
+        'for' => {
+          'resource' => [
+            { 'equals' => { 'kind' => 'project' }, 'allow' => ['create'] }
+          ],
+        },
+        'by' => [{
+          'group'    => ['admin'],
+        }]
+      }
+
+      it { is_expected.to run.with_params(test_policy) }
+    end
+
+    describe 'invalid policy' do
+      it { is_expected.to run.with_params({}).and_raise_error(Puppet::ParseError, //)}
+     
+      context "description" do 
+        it { is_expected.to run.with_params({
+          'context' => {
+            'application' => 'rundeck'
+          }
+        }).and_raise_error(Puppet::ParseError, 'The policy is invalid - description is not a String')}
+      
+        it { is_expected.to run.with_params({
+          'description' => {}
+        }).and_raise_error(Puppet::ParseError, 'The policy is invalid - description is not a String')}
+
+      end
+
+      context "context" do
+        it { is_expected.to run.with_params({
+          'description' => 'test'
+        }).and_raise_error(Puppet::ParseError, 'The policy is invalid - context is not a Hash')}
+
+        it { is_expected.to run.with_params({
+          'description' => 'test',
+          'context'     => {}
+        }).and_raise_error(Puppet::ParseError, 'The policy is invalid - context is empty')}
+
+        it { is_expected.to run.with_params({
+          'description' => 'test',
+          'context'     => ''
+        }).and_raise_error(Puppet::ParseError, 'The policy is invalid - context is not a Hash')}
+      end
+
+      context "context:application" do
+        it { is_expected.to run.with_params({
+          'description' => 'test',
+          'context'     => {
+            'fubar' => ''
+          }
+        }).and_raise_error(Puppet::ParseError, 'The policy is invalid - context can only be project or application')}
+
+        it { is_expected.to run.with_params({
+          'description' => 'test',
+          'context'     => {
+            'application' => {}
+          }
+        }).and_raise_error(Puppet::ParseError, 'The policy is invalid - context:application is not a String')}
+      end
+     
+      context "for" do
+        it { is_expected.to run.with_params({
+          'description' => 'test',
+          'context'     => {
+            'application' => 'rundeck'
+          },
+          'for' => ''
+        }).and_raise_error(Puppet::ParseError, 'The policy is invalid - for is not a Hash')}
+      
+        it { is_expected.to run.with_params({
+          'description' => 'test',
+          'context'     => {
+            'application' => 'rundeck'
+          },
+          'for' => {}
+        }).and_raise_error(Puppet::ParseError, 'The policy is invalid - for is empty')}
+   
+        it { is_expected.to run.with_params({
+          'description' => 'test',
+          'context'     => {
+            'application' => 'rundeck'
+          },
+          'for' => {
+            'fubar' => {}
+          }
+        }).and_raise_error(Puppet::ParseError, "The policy is invalid - for section must only contain ['resource', 'project', 'storage']")}
+      end
+
+      context "for:resource" do
+        it { is_expected.to run.with_params({
+          'description' => 'test',
+          'context'     => {
+            'application' => 'rundeck'
+          },
+          'for' => {
+            'resource' => ''
+          }
+        }).and_raise_error(Puppet::ParseError, "The policy is invalid - for:resource is not an Array")}
+
+        it { is_expected.to run.with_params({
+          'description' => 'test',
+          'context'     => {
+            'application' => 'rundeck'
+          },
+          'for' => {
+            'resource' => {}
+          }
+        }).and_raise_error(Puppet::ParseError, "The policy is invalid - for:resource is not an Array")}
+
+        it { is_expected.to run.with_params({
+          'description' => 'test',
+          'context'     => {
+            'application' => 'rundeck'
+          },
+          'for' => {
+            'resource' => []
+          }
+        }).and_raise_error(Puppet::ParseError, "The policy is invalid - for:resource is empty")}
+      
+        it { is_expected.to run.with_params({
+          'description' => 'test',
+          'context'     => {
+            'application' => 'rundeck'
+          },
+          'for' => {
+            'resource' => [{}]
+          }
+        }).and_raise_error(Puppet::ParseError, "The policy is invalid - for:resource does not contain a rule action of [allow,deny]")}
+
+        it { is_expected.to run.with_params({
+          'description' => 'test',
+          'context'     => {
+            'application' => 'rundeck'
+          },
+          'for' => {
+            'resource' => [
+              { 'equals' => { 'kind' => 'job' }, 'allow' => ['admin'] },
+              ''
+            ]
+          }
+        }).and_raise_error(Puppet::ParseError, "The policy is invalid - for:resource entry is not a Hash")} 
+     end
+
+     context "for:resource rules" do 
+        it { is_expected.to run.with_params({
+          'description' => 'test',
+          'context'     => {
+            'application' => 'rundeck'
+          },
+          'for' => {
+            'resource' => [
+              { 'equals' => { 'kind' => 'job' }, 'fubar' => ['admin'] },
+            ]
+          }
+        }).and_raise_error(Puppet::ParseError, "The policy is invalid - for:resource does not contain a rule action of [allow,deny]")}
+     end
+
+     context "for:resource matching" do
+        it { is_expected.to run.with_params({
+          'description' => 'test',
+          'context'     => {
+            'application' => 'rundeck'
+          },
+          'for' => {
+            'resource' => [
+              { 'fubar' => { 'kind' => 'job' }, 'deny' => ['admin'] },
+            ]
+          }
+        }).and_raise_error(Puppet::ParseError, "The policy is invalid - for:resource does not contain a matching statement of [match,equals,contains]")}
+     end
+
+     context "for:resource kind:project" do
+       it { is_expected.to run.with_params({
+         'description' => 'test',
+         'context'     => {
+           'application' => 'rundeck'
+          },
+          'for' => {
+            'resource' => [
+              { 'equals' => { 'kind' => 'project' }, 'allow' => ['x'] },
+            ]
+          },
+          'by' => [{'group'=>'admins'}]
+       }).and_raise_error(Puppet::ParseError, /^The policy is invalid - for:resource kind:project can only contain actions/) }
+     end
+     
+     context "for:resource kind:system" do
+       it { is_expected.to run.with_params({
+         'description' => 'test',
+         'context'     => {
+           'application' => 'rundeck'
+          },
+          'for' => {
+            'resource' => [
+              { 'equals' => { 'kind' => 'system' }, 'allow' => ['x'] },
+            ]
+          }, 
+          'by' => [{'group'=>'admins'}]
+       }).and_raise_error(Puppet::ParseError, /^The policy is invalid - for:resource kind:system can only contain actions/) }
+     end
+
+     context "for:resource kind:user" do
+       it { is_expected.to run.with_params({
+         'description' => 'test',
+         'context'     => {
+           'application' => 'rundeck'
+          },
+          'for' => {
+            'resource' => [
+              { 'equals' => { 'kind' => 'user' }, 'allow' => ['x'] },
+            ]
+          }
+       }).and_raise_error(Puppet::ParseError, /^The policy is invalid - for:resource kind:user can only contain actions/) }
+     end
+
+     context "for:resource kind:job" do
+       it { is_expected.to run.with_params({
+         'description' => 'test',
+         'context'     => {
+           'application' => 'rundeck'
+         },
+         'for' => {
+           'resource' => [
+             { 'equals' => { 'kind' => 'job' }, 'allow' => ['x'] },
+           ]
+         }
+       }).and_raise_error(Puppet::ParseError, /^The policy is invalid - for:resource kind:job can only contain actions/) }
+     end
+
+     context "for:project" do
+       it { is_expected.to run.with_params({
+         'description' => 'test',
+         'context'     => {
+           'application' => 'rundeck'
+         },
+         'for' => {
+           'project' => ''
+         }
+       }).and_raise_error(Puppet::ParseError, "The policy is invalid - for:project is not an Array")}
+       
+       it { is_expected.to run.with_params({
+         'description' => 'test',
+         'context'     => {
+           'application' => 'rundeck'
+         },
+         'for' => {
+           'project' => {}
+         }
+       }).and_raise_error(Puppet::ParseError, "The policy is invalid - for:project is not an Array")}
+
+       it { is_expected.to run.with_params({
+         'description' => 'test',
+         'context'     => {
+           'application' => 'rundeck'
+         },
+         'for' => {
+           'project' => []
+         }
+       }).and_raise_error(Puppet::ParseError, "The policy is invalid - for:project is empty")}
+      
+       it { is_expected.to run.with_params({
+         'description' => 'test',
+         'context'     => {
+           'application' => 'rundeck'
+         },
+         'for' => {
+           'project' => [{}]
+         }
+       }).and_raise_error(Puppet::ParseError, "The policy is invalid - for:project does not contain a rule action of [allow,deny]")}
+       
+       it { is_expected.to run.with_params({
+         'description' => 'test',
+         'context'     => {
+           'application' => 'rundeck'
+         },
+         'for' => {
+           'project' => [
+             { 'allow' => ['create'] },
+             ''
+           ]
+         }
+       }).and_raise_error(Puppet::ParseError, "The policy is invalid - for:project entry is not a Hash")} 
+     end
+
+     context "for:project rules" do 
+        it { is_expected.to run.with_params({
+          'description' => 'test',
+          'context'     => {
+            'application' => 'rundeck'
+          },
+          'for' => {
+            'project' => [
+              { 'equals' => { 'name' => 'test' }, 'fubar' => ['read'] },
+            ]
+          }
+        }).and_raise_error(Puppet::ParseError, "The policy is invalid - for:project does not contain a rule action of [allow,deny]")}
+     end
+
+     context "for:project matching" do
+        it { is_expected.to run.with_params({
+          'description' => 'test',
+          'context'     => {
+            'application' => 'rundeck'
+          },
+          'for' => {
+            'project' => [
+              { 'fubar' => { 'name' => 'test' }, 'deny' => ['read'] },
+            ]
+          }
+        }).and_raise_error(Puppet::ParseError, "The policy is invalid - for:project does not contain a matching statement of [match,equals,contains]")}
+     end
+
+     context "for:project property:name" do
+       it { is_expected.to run.with_params({
+         'description' => 'test',
+         'context'     => {
+           'application' => 'rundeck'
+         },
+         'for' => {
+           'project' => [
+             { 'equals' => { 'name' => 'test' }, 'allow' => ['x'] },
+           ]
+         },
+         'by' => [{'group' => 'admins'}]
+       }).and_raise_error(Puppet::ParseError, /^The policy is invalid - for:project name can only contain actions/) }
+     end
+
+     context "for:storage" do
+       it { is_expected.to run.with_params({
+         'description' => 'test',
+         'context'     => {
+           'application' => 'rundeck'
+         },
+         'for' => {
+           'storage' => ''
+         }
+       }).and_raise_error(Puppet::ParseError, "The policy is invalid - for:storage is not an Array")}
+       
+       it { is_expected.to run.with_params({
+         'description' => 'test',
+         'context'     => {
+           'application' => 'rundeck'
+         },
+         'for' => {
+           'storage' => {}
+         }
+       }).and_raise_error(Puppet::ParseError, "The policy is invalid - for:storage is not an Array")}
+
+       it { is_expected.to run.with_params({
+         'description' => 'test',
+         'context'     => {
+           'application' => 'rundeck'
+         },
+         'for' => {
+           'storage' => []
+         }
+       }).and_raise_error(Puppet::ParseError, "The policy is invalid - for:storage is empty")}
+      
+       it { is_expected.to run.with_params({
+         'description' => 'test',
+         'context'     => {
+           'application' => 'rundeck'
+         },
+         'for' => {
+           'storage' => [{}]
+         }
+       }).and_raise_error(Puppet::ParseError, "The policy is invalid - for:storage does not contain a rule action of [allow,deny]")}
+       
+       it { is_expected.to run.with_params({
+         'description' => 'test',
+         'context'     => {
+           'application' => 'rundeck'
+         },
+         'for' => {
+           'storage' => [
+             { 'allow' => ['create'] },
+             ''
+           ]
+         }
+       }).and_raise_error(Puppet::ParseError, "The policy is invalid - for:storage entry is not a Hash")} 
+     end
+
+     context "for:storage rules" do 
+        it { is_expected.to run.with_params({
+          'description' => 'test',
+          'context'     => {
+            'application' => 'rundeck'
+          },
+          'for' => {
+            'storage' => [
+              { 'equals' => { 'name' => 'test' }, 'fubar' => ['read'] },
+            ]
+          }
+        }).and_raise_error(Puppet::ParseError, "The policy is invalid - for:storage does not contain a rule action of [allow,deny]")}
+     end
+
+     context "for:storage matching" do
+        it { is_expected.to run.with_params({
+          'description' => 'test',
+          'context'     => {
+            'application' => 'rundeck'
+          },
+          'for' => {
+            'storage' => [
+              { 'fubar' => { 'name' => 'test' }, 'deny' => ['read'] },
+            ]
+          }
+        }).and_raise_error(Puppet::ParseError, "The policy is invalid - for:storage does not contain a matching statement of [match,equals,contains]")}
+     end
+
+     context "for:storage property:name" do
+       it { is_expected.to run.with_params({
+         'description' => 'test',
+         'context'     => {
+           'application' => 'rundeck'
+         },
+         'for' => {
+           'storage' => [
+             { 'equals' => { 'name' => 'test' }, 'allow' => ['x'] },
+           ]
+         },
+         'by' => [{'group' => 'admins'}]
+       }).and_raise_error(Puppet::ParseError, /^The policy is invalid - for:storage name can only contain actions/) }
+     end
+
+     context "for:storage property:path" do
+       it { is_expected.to run.with_params({
+         'description' => 'test',
+         'context'     => {
+           'application' => 'rundeck'
+         },
+         'for' => {
+           'storage' => [
+             { 'equals' => { 'path' => 'test' }, 'allow' => ['x'] },
+           ]
+         },
+         'by' => [{'group' => 'admins'}]
+       }).and_raise_error(Puppet::ParseError, /^The policy is invalid - for:storage path can only contain actions/) }
+     end
+     
+       context "by" do
+       it { is_expected.to run.with_params({
+         'description' => 'test',
+         'context'     => {
+           'application' => 'rundeck'
+         },
+         'for' => {
+           'project' => [
+             { 'equals' => {'name' => 'test' }, 'allow' => ['read'] }
+           ]
+         },
+         'by' => ''
+       }).and_raise_error(Puppet::ParseError, "The policy is invalid - by is not an Array")}
+       
+       it { is_expected.to run.with_params({
+         'description' => 'test',
+         'context'     => {
+           'application' => 'rundeck'
+         },
+         'for' => { 
+           'project' => [
+             { 'equals' => {'name' => 'test' }, 'allow' => ['read'] }
+           ]
+         },
+         'by' => {}
+       }).and_raise_error(Puppet::ParseError, "The policy is invalid - by is not an Array")}
+
+       it { is_expected.to run.with_params({
+         'description' => 'test',
+         'context'     => {
+           'application' => 'rundeck'
+         },
+         'for' => { 
+           'project' => [
+             { 'equals' => {'name' => 'test' }, 'allow' => ['read'] }
+           ]
+         },
+         'by' => []
+       }).and_raise_error(Puppet::ParseError, "The policy is invalid - by is empty")}
+      
+       it { is_expected.to run.with_params({
+         'description' => 'test',
+         'context'     => {
+           'application' => 'rundeck'
+         },
+         'for' => { 
+           'project' => [
+             { 'equals' => {'name' => 'test' }, 'allow' => ['read'] }
+           ]
+         },
+         'by' => [{}]
+       }).and_raise_error(Puppet::ParseError, "The policy is invalid - by is empty")}
+       
+       it { is_expected.to run.with_params({
+         'description' => 'test',
+         'context'     => {
+           'application' => 'rundeck'
+         },
+         'for' => { 
+           'project' => [
+             { 'equals' => {'name' => 'test' }, 'allow' => ['read'] }
+           ]
+         },
+         'by' => [{'username'=>'test'},'']
+       }).and_raise_error(Puppet::ParseError, "The policy is invalid - by: is not a Hash")} 
+     end
+
+   end
+  end
+end

--- a/spec/functions/validate_rd_policy/project_spec.rb
+++ b/spec/functions/validate_rd_policy/project_spec.rb
@@ -1,0 +1,584 @@
+require 'spec_helper'
+
+describe 'validate_rd_policy' do
+
+  describe 'project policy' do
+    describe 'valid policy' do
+      test_policy = {
+        'description' => 'Admin, all access',
+        'context' => {
+          'project' => '.*'
+        },
+        'for' => {
+          'resource' => [
+            { 'equals' => { 'kind' => 'job' }, 'allow' => ['create'] }
+          ],
+        },
+        'by' => [{
+          'group'    => ['admin'],
+        }]
+      }
+
+      it { is_expected.to run.with_params(test_policy) }
+    end
+
+    describe 'invalid policy' do
+      it { is_expected.to run.with_params({}).and_raise_error(Puppet::ParseError, //)}
+     
+      context "description" do 
+        it { is_expected.to run.with_params({
+          'context' => {
+            'project' => '.*'
+          }
+        }).and_raise_error(Puppet::ParseError, 'The policy is invalid - description is not a String')}
+      
+        it { is_expected.to run.with_params({
+          'description' => {}
+        }).and_raise_error(Puppet::ParseError, 'The policy is invalid - description is not a String')}
+
+      end
+
+      context "context" do
+        it { is_expected.to run.with_params({
+          'description' => 'test'
+        }).and_raise_error(Puppet::ParseError, 'The policy is invalid - context is not a Hash')}
+
+        it { is_expected.to run.with_params({
+          'description' => 'test',
+          'context'     => {}
+        }).and_raise_error(Puppet::ParseError, 'The policy is invalid - context is empty')}
+
+        it { is_expected.to run.with_params({
+          'description' => 'test',
+          'context'     => ''
+        }).and_raise_error(Puppet::ParseError, 'The policy is invalid - context is not a Hash')}
+      end
+
+      context "context:project" do
+        it { is_expected.to run.with_params({
+          'description' => 'test',
+          'context'     => {
+            'fubar' => ''
+          }
+        }).and_raise_error(Puppet::ParseError, 'The policy is invalid - context can only be project or application')}
+
+        it { is_expected.to run.with_params({
+          'description' => 'test',
+          'context'     => {
+            'project' => {}
+          }
+        }).and_raise_error(Puppet::ParseError, 'The policy is invalid - context:project is not a String')}
+      end
+     
+      context "for" do
+        it { is_expected.to run.with_params({
+          'description' => 'test',
+          'context'     => {
+            'project' => '.*'
+          },
+          'for' => ''
+        }).and_raise_error(Puppet::ParseError, 'The policy is invalid - for is not a Hash')}
+      
+        it { is_expected.to run.with_params({
+          'description' => 'test',
+          'context'     => {
+            'project' => '.*'
+          },
+          'for' => {}
+        }).and_raise_error(Puppet::ParseError, 'The policy is invalid - for is empty')}
+   
+        it { is_expected.to run.with_params({
+          'description' => 'test',
+          'context'     => {
+            'project' => '.*'
+          },
+          'for' => {
+            'fubar' => {}
+          }
+        }).and_raise_error(Puppet::ParseError, "The policy is invalid - for section must only contain ['job', 'node', 'adhoc', 'project', 'resource']")}
+      end
+
+      context "for:resource" do
+        it { is_expected.to run.with_params({
+          'description' => 'test',
+          'context'     => {
+            'project' => '.*'
+          },
+          'for' => {
+            'resource' => ''
+          }
+        }).and_raise_error(Puppet::ParseError, "The policy is invalid - for:resource is not an Array")}
+
+        it { is_expected.to run.with_params({
+          'description' => 'test',
+          'context'     => {
+            'project' => '.*'
+          },
+          'for' => {
+            'resource' => {}
+          }
+        }).and_raise_error(Puppet::ParseError, "The policy is invalid - for:resource is not an Array")}
+
+        it { is_expected.to run.with_params({
+          'description' => 'test',
+          'context'     => {
+            'project' => '.*'
+          },
+          'for' => {
+            'resource' => []
+          }
+        }).and_raise_error(Puppet::ParseError, "The policy is invalid - for:resource is empty")}
+      
+        it { is_expected.to run.with_params({
+          'description' => 'test',
+          'context'     => {
+            'project' => '.*'
+          },
+          'for' => {
+            'resource' => [{}]
+          }
+        }).and_raise_error(Puppet::ParseError, "The policy is invalid - for:resource does not contain a rule action of [allow,deny]")}
+
+        it { is_expected.to run.with_params({
+          'description' => 'test',
+          'context'     => {
+            'project' => '.*'
+          },
+          'for' => {
+            'resource' => [
+              { 'equals' => { 'kind' => 'job' }, 'allow' => ['create'] },
+              ''
+            ]
+          }
+        }).and_raise_error(Puppet::ParseError, "The policy is invalid - for:resource entry is not a Hash")} 
+     end
+
+     context "for:resource rules" do 
+        it { is_expected.to run.with_params({
+          'description' => 'test',
+          'context'     => {
+            'project' => '.*'
+          },
+          'for' => {
+            'resource' => [
+              { 'equals' => { 'kind' => 'job' }, 'fubar' => ['create'] },
+            ]
+          }
+        }).and_raise_error(Puppet::ParseError, "The policy is invalid - for:resource does not contain a rule action of [allow,deny]")}
+     end
+
+     context "for:resource matching" do
+        it { is_expected.to run.with_params({
+          'description' => 'test',
+          'context'     => {
+            'project' => '.*'
+          },
+          'for' => {
+            'resource' => [
+              { 'fubar' => { 'kind' => 'job' }, 'deny' => ['create'] },
+            ]
+          }
+        }).and_raise_error(Puppet::ParseError, "The policy is invalid - for:resource does not contain a matching statement of [match,equals,contains]")}
+     end
+
+     context "for:resource kind:job" do
+       it { is_expected.to run.with_params({
+         'description' => 'test',
+         'context'     => {
+           'project' => '.*'
+          },
+          'for' => {
+            'resource' => [
+              { 'equals' => { 'kind' => 'job' }, 'allow' => ['x'] },
+            ]
+          }
+       }).and_raise_error(Puppet::ParseError, /^The policy is invalid - for:resource kind:job can only contain actions/) }
+     end
+
+     context "for:resource kind:node" do
+       it { is_expected.to run.with_params({
+         'description' => 'test',
+         'context'     => {
+           'project' => '.*'
+         },
+         'for' => {
+           'resource' => [
+             { 'equals' => { 'kind' => 'node' }, 'allow' => ['x'] },
+           ]
+          }
+        }).and_raise_error(Puppet::ParseError, /^The policy is invalid - for:resource kind:node can only contain actions/) }
+     end
+
+     context "for:resource kind:event" do
+       it { is_expected.to run.with_params({
+         'description' => 'test',
+         'context'     => {
+           'project' => '.*'
+         },
+         'for' => {
+           'resource' => [
+             { 'equals' => { 'kind' => 'event' }, 'allow' => ['x'] },
+           ]
+         }
+       }).and_raise_error(Puppet::ParseError, /^The policy is invalid - for:resource kind:event can only contain actions/) }
+     end
+
+     context "for:adhoc" do
+       it { is_expected.to run.with_params({
+         'description' => 'test',
+         'context'     => {
+           'project' => '.*'
+         },
+         'for' => {
+           'adhoc' => ''
+         }
+       }).and_raise_error(Puppet::ParseError, "The policy is invalid - for:adhoc is not an Array")}
+       
+       it { is_expected.to run.with_params({
+         'description' => 'test',
+         'context'     => {
+           'project' => '.*'
+         },
+         'for' => {
+           'adhoc' => {}
+         }
+       }).and_raise_error(Puppet::ParseError, "The policy is invalid - for:adhoc is not an Array")}
+      
+       it { is_expected.to run.with_params({
+         'description' => 'test',
+         'context'     => {
+           'project' => '.*'
+         },
+         'for' => {
+           'adhoc' => []
+         }
+       }).and_raise_error(Puppet::ParseError, "The policy is invalid - for:adhoc is empty")}
+       
+       it { is_expected.to run.with_params({
+         'description' => 'test',
+         'context'     => {
+           'project' => '.*'
+         },
+         'for' => {
+           'adhoc' => [{}]
+         }
+       }).and_raise_error(Puppet::ParseError, "The policy is invalid - for:adhoc does not contain a rule action of [allow,deny]")}
+       
+       it { is_expected.to run.with_params({
+         'description' => 'test',
+         'context'     => {
+           'project' => '.*'
+         },
+         'for' => {
+           'resource' => [
+             { 'equals' => { 'kind' => 'job' }, 'allow' => ['create'] },
+             ''
+           ]
+         }
+       }).and_raise_error(Puppet::ParseError, "The policy is invalid - for:resource entry is not a Hash")} 
+     end
+
+     context "for:adhoc rules" do 
+        it { is_expected.to run.with_params({
+          'description' => 'test',
+          'context'     => {
+            'project' => '.*'
+          },
+          'for' => {
+            'adhoc' => [
+              { 'fubar' => ['create'] },
+            ]
+          }
+        }).and_raise_error(Puppet::ParseError, "The policy is invalid - for:adhoc does not contain a rule action of [allow,deny]")}
+     
+       it { is_expected.to run.with_params({
+         'description' => 'test',
+         'context'     => {
+           'project' => '.*'
+         },
+         'for' => {
+           'adhoc' => [
+             { 'allow' => ['x'] },
+           ]
+         }
+       }).and_raise_error(Puppet::ParseError, /^The policy is invalid - for:adhoc can only contain actions/) }
+     end
+     
+     context "for:job" do
+       it { is_expected.to run.with_params({
+         'description' => 'test',
+         'context'     => {
+           'project' => '.*'
+         },
+         'for' => {
+           'job' => ''
+         }
+       }).and_raise_error(Puppet::ParseError, "The policy is invalid - for:job is not an Array")}
+       
+       it { is_expected.to run.with_params({
+         'description' => 'test',
+         'context'     => {
+           'project' => '.*'
+         },
+         'for' => {
+           'job' => {}
+         }
+       }).and_raise_error(Puppet::ParseError, "The policy is invalid - for:job is not an Array")}
+
+       it { is_expected.to run.with_params({
+         'description' => 'test',
+         'context'     => {
+           'project' => '.*'
+         },
+         'for' => {
+           'job' => []
+         }
+       }).and_raise_error(Puppet::ParseError, "The policy is invalid - for:job is empty")}
+      
+       it { is_expected.to run.with_params({
+         'description' => 'test',
+         'context'     => {
+           'project' => '.*'
+         },
+         'for' => {
+           'job' => [{}]
+         }
+       }).and_raise_error(Puppet::ParseError, "The policy is invalid - for:job does not contain a rule action of [allow,deny]")}
+       
+       it { is_expected.to run.with_params({
+         'description' => 'test',
+         'context'     => {
+           'project' => '.*'
+         },
+         'for' => {
+           'job' => [
+             { 'allow' => ['create'] },
+             ''
+           ]
+         }
+       }).and_raise_error(Puppet::ParseError, "The policy is invalid - for:job entry is not a Hash")} 
+     end
+
+     context "for:job rules" do 
+        it { is_expected.to run.with_params({
+          'description' => 'test',
+          'context'     => {
+            'project' => '.*'
+          },
+          'for' => {
+            'job' => [
+              { 'equals' => { 'name' => 'job' }, 'fubar' => ['create'] },
+            ]
+          }
+        }).and_raise_error(Puppet::ParseError, "The policy is invalid - for:job does not contain a rule action of [allow,deny]")}
+     end
+
+     context "for:job matching" do
+        it { is_expected.to run.with_params({
+          'description' => 'test',
+          'context'     => {
+            'project' => '.*'
+          },
+          'for' => {
+            'job' => [
+              { 'fubar' => { 'name' => 'job' }, 'deny' => ['create'] },
+            ]
+          }
+        }).and_raise_error(Puppet::ParseError, "The policy is invalid - for:job does not contain a matching statement of [match,equals,contains]")}
+     end
+
+     context "for:job property:name" do
+       it { is_expected.to run.with_params({
+         'description' => 'test',
+         'context'     => {
+           'project' => '.*'
+         },
+         'for' => {
+           'job' => [
+             { 'equals' => { 'name' => 'test-job' }, 'allow' => ['x'] },
+           ]
+         }
+       }).and_raise_error(Puppet::ParseError, /^The policy is invalid - for:job name:test-job can only contain actions/) }
+     end
+
+     context "for:job property:group" do
+       it { is_expected.to run.with_params({
+         'description' => 'test',
+         'context'     => {
+           'project' => '.*'
+         },
+         'for' => {
+           'job' => [
+             { 'equals' => { 'group' => 'test-group' }, 'allow' => ['x'] },
+           ]
+         }
+       }).and_raise_error(Puppet::ParseError, /^The policy is invalid - for:job group:test-group can only contain actions/) }
+     end
+
+     context "for:node" do
+       it { is_expected.to run.with_params({
+         'description' => 'test',
+         'context'     => {
+           'project' => '.*'
+         },
+         'for' => {
+           'node' => ''
+         }
+       }).and_raise_error(Puppet::ParseError, "The policy is invalid - for:node is not an Array")}
+       
+       it { is_expected.to run.with_params({
+         'description' => 'test',
+         'context'     => {
+           'project' => '.*'
+         },
+         'for' => {
+           'node' => {}
+         }
+       }).and_raise_error(Puppet::ParseError, "The policy is invalid - for:node is not an Array")}
+
+       it { is_expected.to run.with_params({
+         'description' => 'test',
+         'context'     => {
+           'project' => '.*'
+         },
+         'for' => {
+           'node' => []
+         }
+       }).and_raise_error(Puppet::ParseError, "The policy is invalid - for:node is empty")}
+      
+       it { is_expected.to run.with_params({
+         'description' => 'test',
+         'context'     => {
+           'project' => '.*'
+         },
+         'for' => {
+           'node' => [{}]
+         }
+       }).and_raise_error(Puppet::ParseError, "The policy is invalid - for:node does not contain a rule action of [allow,deny]")}
+       
+       it { is_expected.to run.with_params({
+         'description' => 'test',
+         'context'     => {
+           'project' => '.*'
+         },
+         'for' => {
+           'node' => [
+             { 'allow' => ['read'] },
+             ''
+           ]
+         }
+       }).and_raise_error(Puppet::ParseError, "The policy is invalid - for:node entry is not a Hash")} 
+     end
+
+     context "for:node rules" do 
+        it { is_expected.to run.with_params({
+          'description' => 'test',
+          'context'     => {
+            'project' => '.*'
+          },
+          'for' => {
+            'node' => [
+              { 'equals' => { 'name' => 'test.mycorp.com' }, 'fubar' => ['read'] },
+            ]
+          }
+        }).and_raise_error(Puppet::ParseError, "The policy is invalid - for:node does not contain a rule action of [allow,deny]")}
+     end
+
+     context "for:node matching" do
+        it { is_expected.to run.with_params({
+          'description' => 'test',
+          'context'     => {
+            'project' => '.*'
+          },
+          'for' => {
+            'node' => [
+              { 'fubar' => { 'name' => 'job' }, 'deny' => ['read'] },
+            ]
+          }
+        }).and_raise_error(Puppet::ParseError, "The policy is invalid - for:node does not contain a matching statement of [match,equals,contains]")}
+     end
+
+     context "for:node property:hostname" do
+       it { is_expected.to run.with_params({
+         'description' => 'test',
+         'context'     => {
+           'project' => '.*'
+         },
+         'for' => {
+           'node' => [
+             { 'equals' => { 'hostname' => 'test.mycorp.com' }, 'allow' => ['x'] },
+           ]
+         }
+       }).and_raise_error(Puppet::ParseError, /^The policy is invalid - for:node can only contain actions/) }
+     end
+
+     context "by" do
+       it { is_expected.to run.with_params({
+         'description' => 'test',
+         'context'     => {
+           'project' => '.*'
+         },
+         'for' => {
+           'node' => [
+             { 'equals' => {'hostname' => 'test.mycorp.com' }, 'allow' => ['read'] }
+           ]
+         },
+         'by' => ''
+       }).and_raise_error(Puppet::ParseError, "The policy is invalid - by is not an Array")}
+       
+       it { is_expected.to run.with_params({
+         'description' => 'test',
+         'context'     => {
+           'project' => '.*'
+         },
+         'for' => { 
+           'node' => [
+             { 'equals' => {'hostname' => 'test.mycorp.com' }, 'allow' => ['read'] }
+           ]
+         },
+         'by' => {}
+       }).and_raise_error(Puppet::ParseError, "The policy is invalid - by is not an Array")}
+
+       it { is_expected.to run.with_params({
+         'description' => 'test',
+         'context'     => {
+           'project' => '.*'
+         },
+         'for' => { 
+           'node' => [
+             { 'equals' => {'hostname' => 'test.mycorp.com' }, 'allow' => ['read'] }
+           ]
+         },
+         'by' => []
+       }).and_raise_error(Puppet::ParseError, "The policy is invalid - by is empty")}
+      
+       it { is_expected.to run.with_params({
+         'description' => 'test',
+         'context'     => {
+           'project' => '.*'
+         },
+         'for' => { 
+           'node' => [
+             { 'equals' => {'hostname' => 'test.mycorp.com' }, 'allow' => ['read'] }
+           ]
+         },
+         'by' => [{}]
+       }).and_raise_error(Puppet::ParseError, "The policy is invalid - by is empty")}
+       
+       it { is_expected.to run.with_params({
+         'description' => 'test',
+         'context'     => {
+           'project' => '.*'
+         },
+         'for' => { 
+           'node' => [
+             { 'equals' => {'hostname' => 'test.mycorp.com' }, 'allow' => ['read'] }
+           ]
+         },
+         'by' => [{'username'=>'test'},'']
+       }).and_raise_error(Puppet::ParseError, "The policy is invalid - by: is not a Hash")} 
+     end
+
+   end
+  end
+end

--- a/spec/functions/validate_rd_policy/signature_spec.rb
+++ b/spec/functions/validate_rd_policy/signature_spec.rb
@@ -1,0 +1,15 @@
+require 'spec_helper'
+
+describe 'validate_rd_policy' do
+  describe 'signature validation' do
+    it { is_expected.not_to eq(nil) }
+    it { is_expected.to run.with_params().and_raise_error(Puppet::ParseError, /wrong number of arguments/i) }
+ 
+    describe 'basic invalid inputs' do
+     it { is_expected.to run.with_params(1).and_raise_error(Puppet::ParseError, /is not a Hash or Array of hashes/) }
+     it { is_expected.to run.with_params(true).and_raise_error(Puppet::ParseError, /is not a Hash or Array of hashes/) }
+     it { is_expected.to run.with_params('one').and_raise_error(Puppet::ParseError, /is not a Hash or Array of hashes/) }
+    end
+
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,7 +1,10 @@
 require 'puppetlabs_spec_helper/module_spec_helper'
 
-RSpec.configure do |c|
-  c.default_facts = {
+RSpec.configure do |config|
+  config.default_facts = {
     :puppetversion    => '3.7.4',
   }
+  config.expect_with :rspec do |c|
+    c.syntax = [:should, :expect]
+  end
 end

--- a/templates/aclpolicy.erb
+++ b/templates/aclpolicy.erb
@@ -1,35 +1,42 @@
 <%- @acl_policies.each_with_index do |policy, index| -%>
 description: <%= policy['description'] %>
 context:
-  <%= policy['context']['type'] %>: '<%= policy['context']['rule'] %>'
+  <%= policy['context'].keys[0] %>: '<%= policy['context'].values[0] %>'
 for:
-<%- policy['resource_types'].each do |resource| -%>
-  <%= resource['type'] %>:
-  <%- resource['rules'].each do |rule| -%>
-    - <%- if rule.has_key? 'filter' -%><%= rule['filter']['filter_type'] -%>:
-        <%= rule['filter']['filter_property'] %>: '<%= rule['filter']['filter_value'] -%>'
-      <% end -%><%= rule['name'] %>:
-        <%- if rule['rule'].is_a?(Array) -%> 
-        <%-   rule['rule'].each do |action| -%>
-        - '<%= action %>'
-        <%-   end -%>
-        <%- else -%>
-        - '<%= rule['rule'] %>'  
-        <%- end -%>
+<%- policy['for'].each do |resource,kind| -%>
+  <%= resource %>:
+  <%- kind.each do |type| -%>
+  <%- type.each do |rule,action| -%>
+  <%- if ['allow','deny'].include?(rule) -%>
+    <%- if type.keys.include?('equals') -%>
+      <%= rule %>: <%= action %>
+    <%- else -%>
+      <%= rule %>: <%- if action.is_a? String -%>'<%= action %>'<%-else-%><%= action %><%-end%>
+    <%- end -%>
+  <%- elsif ['match','equals','contains'].include?(rule) -%>
+    <%- action.each do |k,v| -%>
+    - <%= rule %>:
+      <%- if ['kind','path','name','group'].include?(k) -%><%='  '%><%- else -%><%-end-%>
+      <%= k %>: <%- if v.is_a? String -%>'<%= v %>'<%-else-%><%= v %><%-end%>
+    <%- end -%>
+  <%- end -%>
+  <%- end -%>
   <%- end -%>
 <%- end -%>
 by:
-<%- if !policy['by']['groups'].nil? && policy['by']['groups'] != :undef -%>
+<%- policy['by'].each do |by| -%>
+<%-   if !by['group'].nil? && by['group'] != :undef -%>
   group:
-  <%- policy['by']['groups'].each do |group| -%>
-   - '<%= group %>'
+  <%- by['group'].each do |group| -%>
+    - '<%= group %>'
   <%- end -%>
-<%- end -%>
-<%- if !policy['by']['usernames'].nil? && policy['by']['usernames'] != :undef -%>
+<%-   end -%>
+<%-   if !by['username'].nil? && by['username'] != :undef -%>
   username:
-  <%- policy['by']['usernames'].each do |username| -%>
-   - '<%= username %>'
+  <%- by['username'].each do |username| -%>
+    - '<%= username %>'
   <%- end -%>
+<%-   end -%>
 <%- end -%>
 <%- if index != (@acl_policies.length-1) -%>
 


### PR DESCRIPTION
Given the complexities of writing rundeck's acl policies it has come up
again and again where passing incorrect data into the hash can cause
puppet to generate an invalid policy file.

The point of this change is to restructure the hash so that it better
repsents the structure of the acl policy itself and to provide a parser
function for the policy hash so that the data can be validated.