### PR TITLE
Add rundeck::projects to specify projects in your rundeck instance

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,9 @@ Web context path to use, such as "/rundeck". http://host.domain:port/server_web_
 #####`ssl_enabled`
 Enable ssl for the Rundeck web application.
 
+#####`projects`
+The hash of projects in your instance.
+
 #####`projects_organization`
 The organization value that will be set by default for any projects.
 

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -15,6 +15,7 @@ class rundeck::config(
   $jvm_args              = $rundeck::jvm_args,
   $java_home             = $rundeck::java_home,
   $ssl_enabled           = $rundeck::ssl_enabled,
+  $projects              = $rundeck::projects,
   $projects_organization = $rundeck::projects_default_org,
   $projects_description  = $rundeck::projects_default_desc,
   $rd_loglevel           = $rundeck::rd_loglevel,
@@ -136,4 +137,6 @@ class rundeck::config(
   class { 'rundeck::config::global::project': } ->
   class { 'rundeck::config::global::rundeck_config': } ->
   class { 'rundeck::config::global::ssl': }
+
+  create_resources(rundeck::config::project, $projects)
 }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -43,6 +43,9 @@
 # [*ssl_enabled*]
 #   Enable ssl for the rundeck web application.
 #
+# [*projects*]
+#  The hash of projects in your instance.
+#
 # [*projects_organization*]
 #  The organization value that will be set by default for any projects.
 #
@@ -118,6 +121,7 @@ class rundeck (
   $service_logs_dir             = $rundeck::params::service_logs_dir,
   $ssl_enabled                  = $rundeck::params::ssl_enabled,
   $framework_config             = $rundeck::params::framework_config,
+  $projects                     = $rundeck::params::projects,
   $projects_organization        = $rundeck::params::projects_default_org,
   $projects_description         = $rundeck::params::projects_default_desc,
   $rd_loglevel                  = $rundeck::params::loglevel,
@@ -150,6 +154,7 @@ class rundeck (
   validate_array($auth_types)
   validate_hash($auth_config)
   validate_bool($ssl_enabled)
+  validate_hash($projects)
   validate_string($projects_organization)
   validate_string($projects_description)
   validate_re($rd_loglevel, ['^ALL$', '^DEBUG$', '^ERROR$', '^FATAL$', '^INFO$', '^OFF$', '^TRACE$', '^WARN$'])

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -213,6 +213,7 @@ class rundeck::params {
     'apiCookieAccess'      => true
   }
 
+  $projects = {}
   $projects_default_org = ''
   $projects_default_desc = ''
 


### PR DESCRIPTION
This allows for rundeck::projects to be specified like so, in YAML:

```
rundeck::projects:
  'Infrastructure': {}
  'Applications': {}
  'NOC': {}
```

This creates the projects.