### PR TITLE
Only include ssl bits when ssl is enabled

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -133,10 +133,19 @@ class rundeck::config(
     require => File[$properties_dir]
   }
 
-  class { 'rundeck::config::global::framework': } ->
-  class { 'rundeck::config::global::project': } ->
-  class { 'rundeck::config::global::rundeck_config': } ->
-  class { 'rundeck::config::global::ssl': }
+  include 'rundeck::config::global::framework'
+  include 'rundeck::config::global::project'
+  include 'rundeck::config::global::rundeck_config'
+
+  Class[rundeck::config::global::framework] ->
+  Class[rundeck::config::global::project] ->
+  Class[rundeck::config::global::rundeck_config]
+
+  if $ssl_enabled {
+    include 'rundeck::config::global::ssl'
+    Class[rundeck::config::global::rundeck_config] ->
+    Class[rundeck::config::global::ssl]
+  }
 
   create_resources(rundeck::config::project, $projects)
 }

--- a/spec/classes/config/global/ssl_spec.rb
+++ b/spec/classes/config/global/ssl_spec.rb
@@ -4,7 +4,9 @@ describe 'rundeck' do
   context 'supported operating systems' do
     ['Debian','RedHat'].each do |osfamily|
       describe "rundeck::config::global::ssl class without any parameters on #{osfamily}" do
-        let(:params) {{ }}
+        let(:params) {{
+          :ssl_enabled => true,
+        }}
         let(:facts) {{
           :osfamily        => osfamily,
           :serialnumber    => 0,
@@ -29,7 +31,6 @@ describe 'rundeck' do
             'value'   => value
           ) }
         end
-
       end
     end
   end

--- a/spec/classes/config_spec.rb
+++ b/spec/classes/config_spec.rb
@@ -14,7 +14,6 @@ describe 'rundeck' do
         it { should contain_class('rundeck::config::global::framework') }
         it { should contain_class('rundeck::config::global::project') }
         it { should contain_class('rundeck::config::global::rundeck_config') }
-        it { should contain_class('rundeck::config::global::ssl') }
 
         it { should contain_file('/etc/rundeck').with({'ensure' => 'directory'})}
 

--- a/templates/profile.erb
+++ b/templates/profile.erb
@@ -34,9 +34,8 @@ RDECK_JVM="$RDECK_JVM <%= @jvm_args %>"
 
 <%- if @ssl_enabled -%>
 export RDECK_JVM="$RDECK_JVM -Drundeck.ssl.config=<%= @properties_dir %>/ssl/ssl.properties -Dserver.https.port=<%= @ssl_port %>"
-<%- end -%>
-
 export RDECK_SSL_OPTS="-Djavax.net.ssl.trustStore=$RDECK_BASE/ssl/truststore -Djavax.net.ssl.trustStoreType=jks -Djava.protocol.handler.pkgs=com.sun.net.ssl.internal.www.protocol"
+<%- end -%>
 
 if test -t 0 -a -z "$RUNDECK_CLI_TERSE"
 then


### PR DESCRIPTION
Hello:

I noticed that when ssl isn't enabled, that running rd-jobs from the cli produces ssl warnings:
````
[root@rundeck rundeck]# rd-jobs list -p Infrastructure
Error: Error making server request to http://rundeck:4440: Error occurred while trying to authenticate to server: java.lang.RuntimeException: Unexpected error: java.security.InvalidAlgorithmParameterException: the trustAnchors parameter must be non-empty
````

This PR only calls the SSL bits when it's enabled.