### PR TITLE
fix Evaluation Error on require of puppet/util/rundeck_acl

### DIFF
--- a/lib/puppet/parser/functions/validate_rd_policy.rb
+++ b/lib/puppet/parser/functions/validate_rd_policy.rb
@@ -1,4 +1,4 @@
-require 'puppet/util/rundeck_acl'
+File.expand_path('../../util/rundeck_acl', __FILE__)
 
 module Puppet::Parser::Functions
 


### PR DESCRIPTION
Just the @ak0ska suggestion from @JesperTerkelsen fork on issue #125 