### PR TITLE
remove java dependency from deb

### DIFF
--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -56,7 +56,7 @@ class rundeck::install(
         }
 
         exec { 'install rundeck package':
-          command => "/usr/bin/dpkg --force-confold -i /tmp/rundeck-${package_ensure}.deb",
+          command => "/usr/bin/dpkg --force-confold --ignore-depends 'java7-runtime' -i /tmp/rundeck-${package_ensure}.deb",
           unless  => "/usr/bin/dpkg -l | grep rundeck | grep ${version}",
           require => [ Exec['download rundeck package'], Exec['stop rundeck service'] ]
         }


### PR DESCRIPTION
So java management was already removed from this module, but we still have a java dependency inside the deb package. As a result deployment can fall in case of custom java deployment.

Example:
```
Error: /Stage[main]/Rundeck::Install/Exec[install rundeck package]/returns: change from notrun to 0 failed: /usr/bin/dpkg --force-confold -i /tmp/rundeck-2.5.1-1-GA.deb returned 1 instead of one of [0]
```
```
# /usr/bin/dpkg --force-confold -i /tmp/rundeck-2.5.1-1-GA.deb
(Reading database ... 92055 files and directories currently installed.)
Preparing to unpack /tmp/rundeck-2.5.1-1-GA.deb ...
Unpacking rundeck (2.5.1) over (2.5.1) ...
dpkg: dependency problems prevent configuration of rundeck:
 rundeck depends on java7-runtime | java7-runtime-headless | java8-runtime | java8-runtime-headless; however:
  Package java7-runtime is not installed.
  Package java7-runtime-headless is not installed.
  Package java8-runtime is not installed.
  Package java8-runtime-headless is not installed.

dpkg: error processing package rundeck (--install):
 dependency problems - leaving unconfigured
Processing triggers for ureadahead (0.100.0-16) ...
Errors were encountered while processing:
 rundeck
``` 
In the environment above there is example of deployment of java in `deb-less` way .