### PR TITLE
key storage non-default dir path support

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,9 @@ The name of the role that is required for all users to be allowed access.
 #####`manage_yum_repo`
 Whether to manage the YUM repository containing the Rundeck rpm. Defaults to true.
 
+#####`file_keystorage_dir`
+The location of stored data like public keys, private keys.
+
 ####Define: `aclpolicyfile`
 A definition for creating custom acl policy files
 

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -30,6 +30,7 @@ class rundeck::config(
   $truststore            = $rundeck::truststore,
   $truststore_password   = $rundeck::truststore_password,
   $service_logs_dir      = $rundeck::service_logs_dir,
+  $file_keystorage_dir   = $rundeck::file_keystorage_dir,
   $service_name          = $rundeck::service_name,
   $mail_config           = $rundeck::mail_config,
   $security_config       = $rundeck::security_config,

--- a/manifests/config/global/rundeck_config.pp
+++ b/manifests/config/global/rundeck_config.pp
@@ -13,6 +13,7 @@ class rundeck::config::global::rundeck_config(
   $clustermode_enabled   = $rundeck::config::clustermode_enabled,
   $grails_server_url     = $rundeck::config::grails_server_url,
   $properties_dir        = $rundeck::config::properties_dir,
+  $file_keystorage_dir   = $rundeck::config::file_keystorage_dir,
   $user                  = $rundeck::config::user,
   $group                 = $rundeck::config::group,
   $mail_config           = $rundeck::config::mail_config,

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -118,6 +118,7 @@ class rundeck (
   $api_policies                 = $rundeck::params::api_policies,
   $api_template                 = $rundeck::params::api_template,
   $service_logs_dir             = $rundeck::params::service_logs_dir,
+  $file_keystorage_dir          = $rundeck::params::file_keystorage_dir,
   $ssl_enabled                  = $rundeck::params::ssl_enabled,
   $framework_config             = $rundeck::params::framework_config,
   $projects                     = $rundeck::params::projects,

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -275,4 +275,6 @@ class rundeck::params {
   $session_timeout = 30
 
   $rdeck_config_template = 'rundeck/rundeck-config.erb'
+
+  $file_keystorage_dir = undef
 }

--- a/templates/rundeck-config.erb
+++ b/templates/rundeck-config.erb
@@ -32,3 +32,8 @@ grails.mail.default.from = "<%= @mail_config['defaults.from'] %>"
 <%- end -%>
 grails.serverURL = "<%= @grails_server_url %>"
 rundeck.clusterMode.enabled = "<%= @clustermode_enabled %>"
+<%- if @file_keystorage_dir %>
+rundeck.storage.provider."1".config.baseDir = "<%= @file_keystorage_dir %>"
+rundeck.storage.provider."1".path = "/"
+rundeck.storage.provider."1".type = "file"
+<%- end -%>


### PR DESCRIPTION
This feature allows to modify path of the key storage directory. (The Key Storage container allows storing public keys, private keys, and passwords)

related discussion: https://groups.google.com/forum/#!topic/rundeck-discuss/fzrQ26USTPU