### PR TITLE
disable H2 database logging in log4j.properties

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -250,6 +250,7 @@ class rundeck::params {
     'username'        => '',
     'password'        => '',
     'dialect'         => '',
+    'enable_h2_logs'  => 'on',
   }
 
   $keystore = '/etc/rundeck/ssl/keystore'

--- a/templates/log4j.properties.erb
+++ b/templates/log4j.properties.erb
@@ -61,6 +61,9 @@ log4j.additivity.org.codehaus.groovy.grails.beans.factory=false
 log4j.logger.grails=info,stdout, server-logger
 log4j.additivity.grails=false
 
+# Disable h2database logger if desired (value = on|off)
+log4j.logger.h2database=<%= @database_config['enable_h2_logs'] %>
+
 
 ####################################################################################################
 #


### PR DESCRIPTION
Addresses https://github.com/puppet-community/puppet-rundeck/issues/85

Added option in log4j.properties.erb to disable h2 logging, as this workaround for https://github.com/rundeck/rundeck/issues/1175 still seems to be required